### PR TITLE
Add 9 new Chinese UMR annotation documents (0027-0035)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ env/
 *.tmp
 *.bak
 .cache/
+temp/

--- a/chinese/umr_data/chinese_umr-0027.umr
+++ b/chinese/umr_data/chinese_umr-0027.umr
@@ -1,0 +1,1360 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
+Words: 去年 11 月 5 日晚 ， 跨性别者 阿程 和 阿聪 在 广东 中山 一 酒店 服毒自杀 ， 但 事件 并未 在 第二天 两人 的 遗体 被 发现 后 结束
+
+# sentence level graph:
+(s1b / but-91
+    :ARG1 (s1x / 自杀-01
+        :ARG0 (s1a / and
+            :op1 (s1i2 / individual-person
+                :name (s1n / name
+                    :op1 "阿程")
+                :ARG1-of (s1i4 / identity-91
+                    :ARG2 (s1p2 / person
+                        :ARG1-of (s1h / have-role-91
+                            :ARG3 (s1x5 / 跨性别)
+                            :aspect performance)))
+                :ARG0-of (s1x7 / 服毒-00
+                    :aspect performance))
+            :op2 (s1i3 / individual-person
+                :name (s1n2 / name
+                    :op1 "阿聪")
+                :ARG1-of s1i4
+                :ARG0-of s1x7))
+        :place (s1x8 / 酒店
+            :quant 1
+            :mod (s1c / city
+                :name (s1n3 / name
+                    :op1 "中山")
+                :place (s1p / province
+                    :name (s1n4 / name
+                        :op1 "广东"))))
+        :temporal (s1d / date-entity
+            :month 11
+            :day 5
+            :year (s1x6 / 年
+                :mod (s1x11 / 去)))
+        :temporal (s1x9 / 晚)
+        :aspect performance)
+    :ARG2 (s1x2 / 结束-01
+        :ARG0 (s1x4 / 发现-01
+            :ARG1 (s1x10 / 遗体
+                :part (s1a2 / and
+                    :op1 s1i2
+                    :op2 s1i3))
+            :temporal (s1x12 / 天
+                :ord (s1o / ordinal-entity
+                    :value (s1x1 / 二)))
+            :aspect performance)
+        :ARG1 (s1x3 / 事件)
+        :aspect performance
+        :polarity -))
+
+# alignment:
+s1b: 0-0
+s1x: 16-16
+s1a: 0-0
+s1i2: 8-8
+s1n: 0-0
+s1i4: 0-0
+s1p2: 0-0
+s1h: 0-0
+s1x5: 7-7
+s1x7: 16-16
+s1i3: 10-10
+s1n2: 0-0
+s1x8: 15-15
+s1c: 13-13
+s1n3: 0-0
+s1p: 12-12
+s1n4: 0-0
+s1d: 0-0
+s1x6: 1-1
+s1x11: 1-1
+s1x9: 5-5
+s1x2: 29-29
+s1x4: 27-27
+s1x10: 25-25
+s1a2: 0-0
+s1x12: 22-22
+s1o: 0-0
+s1x1: 22-22
+s1x3: 19-19
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((s1x4 :after s1x2)
+            (document-creation-time :depends-on s1d)
+            (s1d :contained s1x7)
+            (s1x7 :overlap s1x)
+            (s1x :after s1x4))
+    :modal ((author :full-negative s1x2)
+            (author :full-affirmative s1x4)
+            (author :full-affirmative s1x7)
+            (author :full-affirmative s1x)
+            (root :modal author)
+            (author :full-affirmative s1h)
+            (author :full-affirmative s1x2))
+    :coref ((s1a :same-entity s1a2)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+Words: 随着 向 二人 出售 胶囊 的 药物 中介 被 警方 逮捕 ， 在 该 中介处 获取 药物 的 数名 跨性别者 接连 自杀 ， 在 跨性别 圈 中 引起 不小 震撼
+
+# sentence level graph:
+(s2a / and
+    :op1 (s2x / 逮捕-01
+        :ARG0 (s2a2 / armed-organization
+            :name (s2x17 / 警方))
+        :ARG1 (s2x18 / 中介
+            :mod (s2x1 / 药物)
+            :ARG0-of (s2x19 / 出售-01
+                :ARG1 (s2x8 / 胶囊)
+                :ARG2 (s2x22 / 二人)))
+        :temporal (s2x16 / 随着)
+        :aspect performance)
+    :op2 (s2x2 / 自杀-01
+        :ARG0 (s2x3 / 者
+            :ARG0-of (s2x4 / 获取-01
+                :ARG1 (s2x5 / 药物)
+                :place (s2x6 / 中介处
+                    :mod (s2x7 / 该)))
+            :ARG1-of (s2h / have-role-91
+                :ARG3 (s2x23 / 跨性别))
+            :quant (s2x24 / 数))
+        :mod (s2x15 / 接连)
+        :aspect performance
+        :ARG0-of (s2s / s2x9-))
+    :op3 (s2x9 / 引起-01
+        :ARG1 (s2x10 / 震撼-01
+            :mod (s2x11 / 不小))
+        :place (s2x13 / 圈
+            :mod (s2x14 / 跨性别))
+        :aspect performance))
+
+# alignment:
+s2a: 0-0
+s2x: 11-11
+s2a2: 0-0
+s2x17: 10-10
+s2x18: 8-8
+s2x19: 4-4
+s2x8: 5-5
+s2x22: 3-3
+s2x16: 1-1
+s2x2: 22-22
+s2x3: 20-20
+s2x4: 16-16
+s2x6: 15-15
+s2x7: 14-14
+s2h: 0-0
+s2x23: 25-25
+s2x24: 19-19
+s2x15: 21-21
+s2s: 0-0
+s2x9: 28-28
+s2x10: 30-30
+s2x11: 29-29
+s2x13: 26-26
+s2x14: 25-25
+s2x1: 7-7
+s2x5: 17-17
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((s2x19 :after s2x)
+            (s2x :before s2x4)
+            (s2x4 :after s2x2)
+            (s2x2 :after s2x9)
+            (document-creation-time :depends-on s2x19))
+    :modal ((author :full-affirmative s2x9)
+            (author :full-affirmative s2x4)
+            (author :full-affirmative s2x2)
+            (author :full-affirmative s2x19)
+            (author :full-affirmative s2x)
+            (root :modal author))
+    :coref ((s1a :same-entity s2x22)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
+Words: 在此 一年 前 当局 禁止 电商 对 激素类 药物 的 销售 ， 导致 中国 跨 性别圈 的 自杀 现象 不断 加重
+
+# sentence level graph:
+(s3c / consecutive
+    :op1 (s3x / 禁止-01
+        :ARG0 (s3x2 / 当局)
+        :ARG1 (s3x3 / 销售-01
+            :ARG0 (s3x4 / 电商)
+            :ARG1 (s3x5 / 药物
+                :mod (s3x6 / 激素类))
+            :aspect endeavor)
+        :temporal (s3x8 / 前
+            :op1 (s3t / temporal-quantity
+                :quant 1
+                :unit (s3x9 / 年)))
+        :aspect performance)
+    :op2 (s3x10 / 加重-01
+        :ARG1 (s3x11 / 现象
+            :mod (s3x7 / 自杀
+                :ARG0 (s3x16 / 跨-性别圈
+                    :place (s3c3 / country
+                        :name (s3n2 / name
+                            :op1 "中国")))))
+        :mod (s3x14 / 不断)
+        :cause s3x
+        :aspect state))
+
+# alignment:
+s3c: 0-0
+s3x: 5-5
+s3x2: 4-4
+s3x3: 11-11
+s3x4: 6-6
+s3x5: 9-9
+s3x6: 8-8
+s3x8: 3-3
+s3t: 0-0
+s3x9: 2-2
+s3x10: 21-21
+s3x11: 19-19
+s3x7: 18-18
+s3c3: 0-0
+s3n2: 0-0
+s3x14: 20-20
+s3x16: 16-16
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((document-creation-time :before s3x)
+            (s3x :after s3x10)
+            (s3x :contained s3x3))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x10)
+            (author :full-affirmative s3x))
+    :coref ((s3x7 :subset-of s2x2)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94
+Words: 二人 自杀 一个 个月 后 的 12 月 6 日 ， 中山 警方 搜查 并 拘捕 了 在 大湾区 跨性别 圈 中 小有 名气 的 王姓 药物 中介 ， 其 友人 阿酷 和 阿禄 在 Twitter 上 透露 ， 警方 搜查 王姓 中介 的 原因 是 阿程 和 阿聪 服毒 时 所用 的 胶囊 是 从 该 中介处 购得 的 ， 同时 表示 胶囊 中 的 化学品 是 二人 自行 上网 买 的 ， 王姓 中介 本人 对此 事 不知情 ， 事发 时 正 和 阿酷 在 从 东莞 回 广州 的 火车 上
+
+# sentence level graph:
+(s4a / and
+    :op1 (s4a5 / and)
+    :op2 (s4x38 / 在-01
+        :aspect performance
+        :ARG1 (s4x41 / 火车
+            :ARG0-of (s4x42 / 回-01
+                :aspect performance
+                :ARG2 (s4x44 / 东莞))
+                :ARG1 (s4x43 / 广州))
+        :ARG0 (s4a3 / and
+            :op1 s4p2
+            :op2 s4p7)
+        :mod (s4x40 / 正)
+        :temporal (s4x39 / 事发))
+    :op3 (s4x33 / 知情-01
+        :aspect state
+        :ARG0 (s4p7 / person
+            :name (s4n13 / name
+                :op1 "王姓")
+            :mod (s4x37 / 本人)
+            :ARG1-of (s4h4 / have-org-role-92)
+                :ARG3 (s4x36 / 中介))
+        :ARG1 (s4x34 / 事
+            :mod (s4x35 / 此))
+        :polarity -)
+    :op4 (s4x25 / 表示-01
+        :aspect performance
+        :ARG0 s4a1
+        :ARG1 (s4x27 / 买-01
+            :aspect performance
+            :ARG1 (s4x31 / 化学品
+                :place (s4x32 / 胶囊))
+            :place (s4x30 / 上网)
+            :manner (s4x29 / 自行)
+            :ARG0 (s4x28 / 二人))
+        :temporal (s4x26 / 同时))
+    :op5 (s4x15 / 透露-01
+        :aspect performance
+        :ARG1 (s4x17 / 原因
+            :mod (s4x18 / 搜查-01
+                :aspect performance
+                :reason (s4x20 / 购得-01
+                    :aspect performance
+                    :place (s4c3 / company
+                        :name (s4n12 / name
+                            :op1 "中介处")
+                        :mod (s4x24 / 该))
+                    :ARG1 (s4x21 / 胶囊
+                        :ARG1-of (s4x22 / 用-01
+                            :ARG2 (s4x23 / 服毒
+                                :aspect performance)))
+                        :op1 (s4p5 / person
+                            :name (s4n10 / name
+                                :op1 "阿程")))
+                :ARG1 (s4p4 / person
+                    :name (s4n9 / name
+                        :op1 "王姓"))
+                    :ARG3 (s4x19 / 中介)))
+        :place (s4c2 / company
+            :name (s4n7 / name
+                :op1 "Twitter"))
+        :ARG0 (s4a1 / and
+                :ARG3 (s4x16 / 友人)
+                :ARG2 s4p7
+            :op1 (s4p3 / person
+                :name (s4n6 / name
+                    :op1 "阿禄"))
+            :op2 (s4p2 / person
+                :name (s4n5 / name
+                    :op1 "阿酷")))
+        :ARG0 (s4g / government-organization
+            :name (s4n / name
+                :op1 "警方")
+            :place (s4c / country-region
+                :name (s4n1 / name
+                    :op1 "中山")))))
+
+# alignment:
+s4a: 0-0
+s4a5: 0-0
+s4x41: 93-93
+s4x42: 90-90
+s4x44: 89-89
+s4x43: 91-91
+s4a3: 0-0
+s4x40: 84-84
+s4x39: 82-82
+s4x33: 80-80
+s4p7: 0-0
+s4n13: 0-0
+s4x37: 77-77
+s4h4: 0-0
+s4x34: 79-79
+s4x35: 78-78
+s4x25: 63-63
+s4x27: 72-72
+s4x31: 67-67
+s4x30: 71-71
+s4x29: 70-70
+s4x26: 62-62
+s4x15: 38-38
+s4x17: 45-45
+s4x20: 59-59
+s4c3: 58-58
+s4n12: 0-0
+s4x24: 57-57
+s4x22: 52-52
+s4x23: 50-50
+s4p5: 0-0
+s4n10: 0-0
+s4p4: 0-0
+s4n9: 0-0
+s4c2: 36-36
+s4n7: 0-0
+s4a1: 0-0
+s4x16: 31-31
+s4p3: 0-0
+s4n6: 0-0
+s4p2: 0-0
+s4n5: 0-0
+s4n: 0-0
+s4c: 12-12
+s4n1: 0-0
+s4x38: 87-87
+s4x36: 76-76
+s4x32: 64-64
+s4x28: 69-69
+s4x18: 41-41
+s4x21: 54-54
+s4x19: 43-43
+s4g: 40-40
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((s4x15 :before s4x23)
+            (s4x23 :overlap s4x22)
+            (s4x22 :before s4x20)
+            (s4x20 :after s4x25)
+            (s4x25 :after s4x27)
+            (s4x27 :overlap s4x33)
+            (s4x33 :overlap s4x38)
+            (s4x38 :overlap s4x42))
+    :modal ((root :modal author)
+            (s4a1 :full-affirmative s4x15)
+            (s4a1 :full-affirmative s4x25)
+            (s4x28 :full-affirmative s4x27)
+            (s4p7 :full-affirmative s4x33)
+            (s4a3 :full-affirmative s4x38)
+            (s4x41 :full-affirmative s4x42)
+            (author :full-affirmative s4x38)
+            (author :full-affirmative s4x42)
+            (author :full-negative s4x33)
+            (author :full-affirmative s4x25)
+            (author :full-affirmative s4x27)
+            (author :full-affirmative s4x15)
+            (author :full-affirmative s4x18)
+            (author :full-affirmative s4x20)
+            (author :full-affirmative s4x22)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38
+Words: 搜查 王姓 中介 的 同时 ， 警方 也 搜查 了 其 友人 阿鱼 的 租住处 ， 在 两处 查扣 了 电子 设备 和 大量 的 药品 ， 包括 阿鱼 以 合法 方式 从 医院 获得 的 精神科 药物
+
+# sentence level graph:
+(s5c / consecutive
+    :op1 (s5x / 搜查-01
+        :ARG0 (s5x6 / 警方)
+        :ARG1 (s5x2 / 租住处
+            :possessor (s5i3 / individual-person
+                :name (s5n / name
+                    :op1 "阿鱼")
+                :ARG1-of (s5h / have-rel-role-91
+                    :ARG2 s5p
+                    :ARG3 (s5x3 / 友人))))
+        :temporal (s5x9 / 同时
+            :op1 (s5x4 / 搜查-01
+                :ARG0 s5x6
+                :ARG1 (s5p / person
+                    :name (s5n2 / name
+                        :op1 "王")
+                    :ARG1-of (s5h4 / have-org-role-91
+                        :ARG3 (s5x5 / 中介)))
+                :aspect performance))
+        :aspect performance)
+    :op2 (s5x10 / 查扣-01
+        :ARG1 (s5a3 / and
+            :op1 (s5x11 / 设备
+                :mod (s5x14 / 电子))
+            :op2 (s5x12 / 药品
+                :quant (s5x13 / 大量)
+                :example (s5x8 / 药物
+                    :mod (s5x16 / 精神科)
+                    :ARG1-of (s5x22 / 获得-01
+                        :ARG0 s5i3
+                        :ARG2 (s5x23 / 医院)
+                        :manner (s5x17 / 合法)))))
+        :place (s5x15 / 处
+            :quant 2)
+        :aspect performance))
+
+# alignment:
+s5c: 0-0
+s5x6: 7-7
+s5x2: 15-15
+s5n: 0-0
+s5h: 0-0
+s5x3: 12-12
+s5x9: 5-5
+s5p: 0-0
+s5n2: 0-0
+s5h4: 0-0
+s5x5: 3-3
+s5x10: 19-19
+s5a3: 0-0
+s5x11: 22-22
+s5x14: 21-21
+s5x12: 26-26
+s5x13: 24-24
+s5x8: 38-38
+s5x16: 37-37
+s5x22: 35-35
+s5x23: 34-34
+s5x17: 31-31
+s5x: 9-9
+s5i3: 13-13
+s5x4: 1-1
+s5x15: 18-18
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((s5x4 :overlap s5x)
+            (s5x :after s5x10)
+            (s5x10 :before s5x22)
+            (document-creation-time :depends-on s5x))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x)
+            (author :full-affirmative s5x10)
+            (author :full-affirmative s5x4)
+            (author :full-affirmative s5x22)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
+Words: 被 警方 带走 的 阿鱼 试图 自残 后 获释 ， 但 王姓 中介 则 被 警方 拘留 ， 并 很快 被 以 妨碍 药品 管理 罪 正式 逮捕
+
+# sentence level graph:
+(s6a / and
+    :op1 (s6x8 / 逮捕-01
+        :aspect performance
+        :reason (s6x11 / 妨碍-01
+            :aspect performance
+            :ARG1 (s6x12 / 管理-01
+                :ARG1 (s6x13 / 药品))
+            :ARG0 s6p)
+        :mod (s6x10 / 很快)
+        :manner (s6x9 / 正式)
+        :ARG1 s6p
+        :ARG0 s6g)
+    :op2 (s6x5 / 拘留-01
+        :aspect performance
+        :mod (s6x7 / 则)
+        :ARG1 (s6p / person
+                  :name (s6n2 / name :op1 "王姓")
+            :ARG1-of (s6h / have-org-role-92)
+                :ARG3 (s6x6 / 中介))
+        :ARG0 s6g)
+    :op3 (s6x3 / 获释-01
+        :aspect performance
+        :temporal (s6x4 / 后
+            :op1 s6x)
+        :ARG0 s6a2)
+    :op4 (s6x / 试图-00
+        :aspect endeavor
+        :ARG1 (s6x1 / 自残
+            :aspect performance)
+        :ARG0 (s6a2 / individual-person
+            :ARG1-of (s6x2 / 带走-01
+                :aspect performance
+                :ARG0 (s6g / government-organization
+                          :name (s6n1 / name :op1 "警方")))
+            :name (s6n / name
+                :op1 "阿鱼"))))
+
+# alignment:
+s6a: 0-0
+s6x8: 28-28
+s6x11: 23-23
+s6x12: 25-25
+s6x13: 24-24
+s6x10: 20-20
+s6x9: 27-27
+s6x5: 17-17
+s6x7: 14-14
+s6p: 0-0
+s6n2: 0-0
+s6h: 0-0
+s6x6: 13-13
+s6x3: 9-9
+s6x4: 8-8
+s6x: 6-6
+s6x1: 7-7
+s6a2: 0-0
+s6x2: 3-3
+s6n1: 0-0
+s6n: 0-0
+s6g: 2-2
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((s6x :overlap s6x1)
+            (s6x1 :after s6x3)
+            (s6x3 :after s6x5)
+            (s6x5 :before s6x11)
+            (s6x11 :after s6x8)
+            (document-creation-time :depends-on s6x2)
+            (s6x2 :after s6x))
+    :modal ((root :modal author)
+            (author :full-affirmative s6x3)
+            (author :full-affirmative s6x)
+            (author :full-affirmative s6x1)
+            (author :full-affirmative s6x11)
+            (author :full-affirmative s6x2)
+            (author :full-affirmative s6x5)
+            (author :full-affirmative s6x8)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 阿酷 在 Twitter 上 表示 警方 并没有 就 此事 通知 其 家属 ， 联系 上 后 其 早已 不 来往 的 父母 也 非常 冷淡
+
+# sentence level graph:
+(s7a2 / and
+    :op1 (s7x3 / 表示-01
+        :ARG0 (s7i3 / individual-person
+            :name (s7n2 / name
+                :op1 "阿酷"))
+        :ARG1 (s7x7 / 通知-01
+            :ARG0 (s7g / government-organization
+                      :name (s7n1 / name :op1 "警方"))
+            :ARG1 (s7x11 / 此事)
+            :ARG2 (s7f / family
+                :ARG1-of (s7h / have-rel-role-91
+                    :ARG2 s7i3
+                    :ARG3 (s7x8 / 家属)))
+            :polarity -
+            :aspect performance)
+        :place (s7c2 / company
+            :name (s7n / name
+                :op1 "twitter"))
+        :aspect performance)
+    :op2 (s7x5 / 冷淡-01
+        :ARG0 s7i3
+        :ARG1 (s7f2 / family
+            :ARG1-of (s7h2 / have-rel-role-91
+                :ARG2 s7i3
+                :ARG3 (s7x2 / 父母))
+            :ARG1-of (s7x / 联系-01)
+            :mod (s7x12 / 来往-02
+                :polarity -
+                :temporal (s7x13 / 早已)))
+        :mod (s7x4 / 非常)
+        :temporal (s7x9 / 后
+            :op1 s7x)
+        :aspect performance))
+
+# alignment:
+s7a2: 0-0
+s7x3: 5-5
+s7i3: 0-0
+s7n2: 0-0
+s7x7: 10-10
+s7g: 6-6
+s7n1: 0-0
+s7x11: 9-9
+s7f: 0-0
+s7h: 0-0
+s7x8: 12-12
+s7c2: 0-0
+s7n: 0-0
+s7x5: 25-25
+s7f2: 0-0
+s7h2: 0-0
+s7x2: 22-22
+s7x: 14-14
+s7x12: 20-20
+s7x13: 18-18
+s7x4: 24-24
+s7x9: 16-16
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((s7x3 :before s7x7)
+            (s7x7 :after s7x)
+            (s7x :before s7x12)
+            (s7x12 :after s7x5)
+            (document-creation-time :depends-on s7x3))
+    :modal ((root :modal author)
+            (s7i3 :full-affirmative s7x)
+            (s7i3 :full-negative s7x12)
+            (author :full-affirmative s7i3)
+            (author :full-affirmative s7x3)
+            (s7i3 :full-negative s7x7)
+            (s7i3 :full-affirmative s7x5)
+            (author :full-affirmative s7x7)
+            (author :full-affirmative s7x5)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34
+Words: 王姓 中介 曾经 确诊 双相 情感 障碍 ， 但 由于 其 父亲 以 工作 忙 为由 拖到 检察院 七天 审核期 的 第八天 才 提交 病历 ， 中山 检方 仍然 决定 重新 做 精神 鉴定
+
+# sentence level graph:
+(s8b / but-91
+    :ARG1 (s8x / 确诊-01
+        :ARG0 (s8i2 / individual-person
+            :name (s8n2 / name
+                :op1 "clan"
+                :op2 "王")
+            :ARG1-of (s8h / have-org-role-91
+                :ARG3 (s8x21 / 中介)))
+        :ARG1 (s8x2 / 障碍
+            :mod (s8x3 / 情感
+                :mod (s8x4 / 双相)))
+        :aspect performance
+        :time (s8x22 / 曾经))
+    :ARG2 (s8x6 / 决定-01
+        :mod (s8x1 / 仍然)
+        :ARG0 (s8x15 / 检方
+            :place (s8c3 / city-district
+                :name (s8n4 / name
+                    :op1 "中山")))
+        :ARG1 (s8x5 / 鉴定
+            :purpose-of (s8x8 / 做-01
+                :mod (s8x9 / 重新)
+                :aspect performance)
+            :mod (s8x10 / 精神))
+        :reason (s8x11 / 拖到-01
+            :ARG0 (s8x14 / 父亲
+                :possessor s8i2)
+            :ARG1 (s8t / temporal-quantity
+                :mod (s8x16 / 审核期
+                    :mod (s8t2 / temporal-quantity
+                        :unit (s8x17 / 天)
+                        :quant (s8x18 / 七))
+                    :mod (s8x20 / 检察院))
+                :unit (s8x23 / 天)
+                :quant (s8x24 / 八))
+            :ARG2 (s8x13 / 病历
+                :ARG1-of (s8x12 / 提交-01)
+                    :aspect performance)
+            :reason (s8x19 / 忙-01
+                :ARG1 (s8x7 / 工作)
+                :aspect state)
+            :aspect performance)
+        :aspect performance))
+
+# alignment:
+s8b: 0-0
+s8x: 4-4
+s8i2: 0-0
+s8n2: 0-0
+s8h: 0-0
+s8x21: 2-2
+s8x2: 7-7
+s8x3: 6-6
+s8x4: 5-5
+s8x22: 3-3
+s8x6: 30-30
+s8x1: 29-29
+s8x15: 28-28
+s8c3: 27-27
+s8n4: 0-0
+s8x5: 34-34
+s8x8: 32-32
+s8x9: 31-31
+s8x10: 33-33
+s8x11: 17-17
+s8x14: 12-12
+s8t: 0-0
+s8x16: 20-20
+s8t2: 0-0
+s8x18: 19-19
+s8x20: 18-18
+s8x24: 22-22
+s8x13: 25-25
+s8x12: 24-24
+s8x19: 15-15
+s8x7: 14-14
+s8x17: 19-19
+s8x23: 19-19
+
+# document level annotation:
+(s8s0 / sentence
+    :temporal ((s8x :after s8x11)
+            (s8x6 :after s8x8)
+            (document-creation-time :depends-on s8x)
+            (s8x11 :after s8x12)
+            (s8x12 :after s8x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s8x)
+            (author :full-affirmative s8x11)
+            (author :full-affirmative s8x12)
+            (author :full-affirmative s8x6)
+            (author :full-affirmative s8x8)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
+Words: 今年 1 月 8 日 ， 无法 再 联系上 王姓 中介 的 家属 的 阿禄 服下 了 过量 的 药品 ， 并于 四天 后 抢救 无效 去世
+
+# sentence level graph:
+(s9c / consecutive
+    :op1 (s9x4 / 服下
+        :ARG0 (s9i2 / individual-person
+            :name (s9n2 / name
+                :op1 "阿禄")
+            :ARG0-of (s9x14 / 联系-01
+                :ARG1 (s9f / family
+                    :ARG1-of (s9h / have-rel-role-91
+                        :ARG2 (s9x15 / 中介
+                            :mod (s9x16 / 王姓))
+                        :ARG3 (s9x17 / 家属)))
+                :mod (s9x6 / 无法)
+                :mod (s9x7 / 再)))
+        :ARG1 (s9x8 / 药品
+            :quant (s9x9 / 过量))
+        :temporal (s9d2 / date-entity
+            :year (s9x5 / 今年)
+            :month 1
+            :day 8)
+        :aspect performance)
+    :op2 (s9x2 / 去世-01
+        :ARG0 s9i2
+        :aspect performance
+        :mod (s9x / 抢救-01
+            :mod (s9x3 / 无效-01))
+        :temporal (s9x10 / 后
+            :quant (s9x11 / 四)
+            :unit (s9x12 / 天))))
+
+# alignment:
+s9c: 0-0
+s9x4: 16-16
+s9i2: 0-0
+s9n2: 0-0
+s9x14: 9-9
+s9f: 0-0
+s9h: 0-0
+s9x15: 11-11
+s9x16: 10-10
+s9x17: 13-13
+s9x6: 7-7
+s9x7: 8-8
+s9x8: 20-20
+s9x9: 18-18
+s9d2: 0-0
+s9x5: 1-1
+s9x2: 27-27
+s9x: 25-25
+s9x3: 26-26
+s9x10: 24-24
+s9x11: 23-23
+s9x12: 23-23
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((document-creation-time :depends-on s9d2)
+            (s9d2 :contained s9x14)
+            (s9x14 :after s9x4)
+            (s9x4 :after s9x)
+            (s9x :after s9x2))
+    :modal ((root :modal author)
+            (author :full-negative s9x14)
+            (author :full-affirmative s9x4)
+            (author :full-affirmative s9x)
+            (author :full-affirmative s9x2)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+Words: 2 月 19 日 ， 几 个 月 来 多次 试图 自杀 的 阿鱼 坠楼 ， 2 月 28 日 ， 处理 完 阿鱼 遗物 的 阿酷 同样 选择 了 自杀
+
+# sentence level graph:
+(s10c / consecutive
+    :op1 (s10x13 / 坠楼-01
+        :ARG0 (s10i4 / individual-person
+            :name (s10n3 / name
+                :op1 "阿鱼")
+            :ARG0-of (s10x7 / 试图-01
+                :ARG1 (s10x15 / 自杀-01)
+                :frequency (s10x4 / 多次)
+                :range (s10t / temporal-quantity
+                    :quant (s10x5 / 几-个)
+                    :unit (s10x16 / 月))
+                :aspect performance))
+        :temporal (s10d3 / date-entity
+            :month 2
+            :day 19)
+        :aspect performance)
+    :op2 (s10x2 / 选择-01
+        :ARG0 (s10i3 / individual-person
+            :name (s10n2 / name
+                :op1 "阿酷")
+            :ARG1-of (s10x / 处理-02
+                :ARG1 (s10x9 / 遗物
+                    :possessor s10i4)
+                :aspect performance))
+        :ARG1 (s10x11 / 自杀-01
+            :aspect performance)
+        :manner (s10x12 / 同样)
+        :temporal (s10d2 / date-entity
+            :day 28
+            :month 2)
+        :aspect performance))
+
+# alignment:
+s10c: 0-0
+s10x13: 15-15
+s10i4: 0-0
+s10n3: 0-0
+s10x7: 11-11
+s10x4: 10-10
+s10t: 0-0
+s10d3: 0-0
+s10x2: 29-29
+s10i3: 27-27
+s10n2: 0-0
+s10x: 22-22
+s10x9: 25-25
+s10x12: 28-28
+s10d2: 0-0
+s10x15: 12-12
+s10x5: 6-6
+s10x16: 8-8
+s10x11: 31-31
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((document-creation-time :depends-on s10d3)
+            (s10d3 :before s10x7)
+            (s10x7 :overlap s10x15)
+            (s10d3 :contained s10x13)
+            (s10d3 :after s10d2)
+            (s10d2 :contained s10x)
+            (s10x :after s10x2)
+            (s10x2 :overlap s10x11))
+    :modal ((root :modal author)
+            (author :full-affirmative s10x7)
+            (author :full-affirmative s10x15)
+            (author :full-affirmative s10x13)
+            (author :full-affirmative s10x)
+            (author :full-affirmative s10x2)
+            (author :full-affirmative s10x11)))
+
+
+################################################################################
+# meta-info
+# :: snt11
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36
+Words: 中国 跨性别 群体 常常 面临 来自 家庭 和 当局 的 双重 压力 ， 2022 年 12 月 ， 中国 药监局 公布 禁止 网上 销售 的 药物 名单 ， 包括 数种 跨女 常用 的 激素 类 药物
+
+# sentence level graph:
+(s11c / consecutive
+    :op1 (s11x / 面临-01
+        :ARG0 (s11x2 / 群体
+            :mod (s11x3 / 跨性别)
+            :place (s11c2 / country
+                :name (s11n3 / name
+                    :op1 "中国")))
+        :ARG1 (s11x4 / 压力
+            :ARG0-of (s11x5 / 来自-01
+                :ARG1 (s11a / and
+                    :op1 (s11x6 / 家庭)
+                    :op2 (s11x7 / 当局))
+                :aspect state)
+            :mod (s11x8 / 双重))
+        :aspect state
+        :frequency (s11x9 / 常常))
+    :op2 (s11x10 / 公布-01
+        :ARG0 (s11g / government-organization
+            :name (s11n / name
+                :op1 "药监局")
+            :place (s11c4 / country
+                :name (s11n2 / name
+                    :op1 "中国")))
+        :ARG1 (s11x11 / 名单
+            :topic (s11x13 / 药物
+                :ARG0-of (s11x14 / 包括-01
+                    :ARG1 (s11x24 / 药物
+                        :mod (s11x16 / 类
+                            :mod (s11x17 / 激素))
+                        :ARG1-of (s11x18 / 常用-01
+                            :ARG0 (s11x19 / 跨女)
+                            :aspect habitual)
+                        :quant (s11x15 / 数种))
+                    :aspect state))
+            :ARG1-of (s11x22 / 销售-01
+                :place (s11x21 / 网上)
+                :ARG1-of (s11x12 / 禁止-01)
+                :aspect habitual))
+        :temporal (s11d / date-entity
+            :year 2022
+            :month 12)
+        :aspect performance))
+
+# alignment:
+s11c: 0-0
+s11x: 5-5
+s11x2: 3-3
+s11x3: 2-2
+s11n3: 0-0
+s11x4: 12-12
+s11x5: 6-6
+s11a: 0-0
+s11x6: 7-7
+s11x7: 9-9
+s11x8: 11-11
+s11x9: 4-4
+s11x10: 21-21
+s11g: 20-20
+s11n: 0-0
+s11c4: 0-0
+s11n2: 0-0
+s11x11: 27-27
+s11x14: 29-29
+s11x16: 35-35
+s11x17: 34-34
+s11x18: 32-32
+s11x19: 31-31
+s11x15: 30-30
+s11x22: 24-24
+s11x21: 23-23
+s11x12: 22-22
+s11d: 0-0
+s11c2: 1-1
+s11x13: 26-26
+s11x24: 36-36
+
+# document level annotation:
+(s11s0 / sentence
+    :temporal ((s11x10 :overlap s11x12)
+            (document-creation-time :depends-on s11d)
+            (s11x :contained s11d)
+            (s11d :contained s11x10))
+    :modal ((root :modal author)
+            (author :full-affirmative s11x)
+            (author :full-affirmative s11x10)
+            (author :full-affirmative s11x12)
+            (author :full-affirmative s11x5)
+            (author :full-affirmative s11x14)
+            (author :full-affirmative s11x18)
+            (author :full-negative s11x22)))
+
+
+################################################################################
+# meta-info
+# :: snt12
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+Words: 由于 相关 医疗 资源 不足 导致 难以 凭医师 的 诊断 和 处方 获得 ， 这些 药物 很多 情况 下 只能 从 网上 购买
+
+# sentence level graph:
+(s12x / 只能
+    :aspect state
+    :reason (s12x6 / 获得-01
+        :aspect state
+        :cause (s12x11 / 不足-01
+            :aspect state
+            :ARG0 (s12x13 / 资源)
+                :mod (s12x14 / 医疗)
+                    :mod (s12x15 / 相关))
+        :manner (s12a / and
+            :ARG1-of (s12x12 / 凭-01)
+            :mod (s12x10 / 医师的)
+            :op1 (s12x9 / 处方)
+            :op2 (s12x8 / 诊断))
+        :mod (s12x7 / 难以)
+        :ARG1 s12x3)
+    :ARG0 (s12x2 / 购买-01
+        :aspect state
+        :temporal (s12x4 / 情况
+            :mod (s12x20 / 很多))
+        :ARG1 (s12x3 / 药物
+            :mod (s12x1 / 这些))
+        :place (s12x5 / 网上)))
+
+# alignment:
+s12x: 20-20
+s12x6: 13-13
+s12x11: 5-5
+s12x13: 4-4
+s12x14: 3-3
+s12x15: 2-2
+s12a: 0-0
+s12x12: 8-8
+s12x10: 9-9
+s12x9: 12-12
+s12x8: 10-10
+s12x7: 7-7
+s12x2: 23-23
+s12x4: 18-18
+s12x20: 17-17
+s12x3: 16-16
+s12x1: 15-15
+s12x5: 22-22
+
+# document level annotation:
+(s12s0 / sentence
+    :temporal ((s12x :after s12x2)
+            (document-creation-time :depends-on s12x6)
+            (s12x6 :after s12x))
+    :modal ((root :modal author)
+            (author :full-affirmative s12x)
+            (author :full-affirmative s12x2)
+            (author :full-affirmative s12x6)
+            (author :full-negative s12x11)))
+
+
+################################################################################
+# meta-info
+# :: snt13
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+Words: 禁令 引发 了 跨 女群体 的 恐慌 ， 有 活动 人士 在受 媒体 访问 时 表示 禁令 出台 后 的 几个月 自杀者 “ 明显 比 往年 同样 的 时间段 多 ”
+
+# sentence level graph:
+(s13c / consecutive
+    :op1 (s13x / 引发-01
+        :ARG0 (s13x2 / 禁令)
+        :ARG1 (s13x3 / 恐慌
+            :mod (s13x14 / 女群体
+                :mod (s13x4 / 跨)))
+        :aspect performance)
+    :op2 (s13x6 / 表示-01
+        :ARG0 (s13x7 / 人士
+            :mod (s13x5 / 活动))
+        :ARG1 (s13x11 / 多-01
+            :temporal (s13x9 / 后
+                :op1 (s13x12 / 出台-01
+                    :aspect performance
+                    :ARG1 (s13x20 / 禁令)))
+            :duration (s13t / temporal-quantity
+                :quant (s13x18 / 几个)
+                :unit (s13x19 / 月))
+            :ARG3-of (s13h / have-degree-91
+                :ARG1 (s13x10 / 自杀者)
+                :ARG4 (s13x13 / 时间段
+                    :mod (s13x8 / 同样
+                        :mod (s13x16 / 往年)))
+                :mod (s13x17 / 明显))
+            :aspect performance)
+        :temporal (s13x15 / 时
+            :op1 (s13x21 / 受-02
+                :aspect performance
+                :ARG1 (s13x22 / 访问
+                    :mod (s13x23 / 媒体))))
+        :aspect performance))
+
+# alignment:
+s13c: 0-0
+s13x: 2-2
+s13x3: 7-7
+s13x14: 5-5
+s13x4: 4-4
+s13x6: 16-16
+s13x7: 11-11
+s13x5: 10-10
+s13x11: 30-30
+s13x9: 19-19
+s13x12: 18-18
+s13t: 0-0
+s13x18: 21-21
+s13x19: 21-21
+s13h: 0-0
+s13x10: 22-22
+s13x13: 29-29
+s13x8: 27-27
+s13x16: 26-26
+s13x17: 24-24
+s13x15: 15-15
+s13x21: 12-12
+s13x22: 14-14
+s13x23: 13-13
+s13x2: 1-1
+s13x20: 17-17
+
+# document level annotation:
+(s13s0 / sentence
+    :temporal ((document-creation-time :depends-on s13x))
+    :modal ((root :modal author)
+            (author :full-affirmative s13x)
+            (author :full-affirmative s13x21)
+            (author :full-affirmative s13x6)
+            (author :full-affirmative s13x7)
+            (s13x7 :full-affirmative s13x11)
+            (author :full-affirmative s13x11)
+            (author :full-affirmative s13x12)))
+
+
+################################################################################
+# meta-info
+# :: snt14
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
+Words: 在 此 背景 下 ， 大部分 继续 服药 者 不得不 从 非法 渠道 获得 药物 ， 包括 早已 被 禁止 的 海外 代购 ， 有 的 还 使用 动物 用药 甚至 自制 药物
+
+# sentence level graph:
+(s14a / and
+    :op1 (s14x24 / 获得-01
+        :ARG1 (s14x3 / 药物)
+        :ARG0 (s14x25 / 者
+            :mod (s14x26 / 服药
+                :mod (s14x1 / 继续))
+            :quant (s14x28 / 大部分))
+        :ARG2 (s14x4 / 渠道
+            :mod (s14x14 / 非法)
+            :ARG0-of (s14x2 / 包括-01)
+                :ARG1 (s14x / 代购
+                    :ARG1-of (s14x6 / 禁止-01
+                        :aspect performance)
+                        :mod (s14x7 / 早已))
+                    :mod (s14x5 / 海外))
+        :manner (s14x15 / 不得不)
+        :aspect habitual)
+    :op2 (s14x11 / 使用-01
+        :ARG1 (s14a1 / and
+            :op1 (s14x12 / 药物
+                :mod (s14x13 / 自制))
+            :op2 (s14x8 / 用药)
+                :mod (s14x10 / 动物))
+        :ARG0 s14x25
+        :mod (s14x9 / 还)
+        :aspect habitual)
+    :cause (s14x19 / 背景
+        :mod (s14x20 / 此)))
+
+# alignment:
+s14a: 0-0
+s14x24: 14-14
+s14x25: 9-9
+s14x26: 8-8
+s14x1: 7-7
+s14x28: 6-6
+s14x4: 13-13
+s14x14: 12-12
+s14x2: 17-17
+s14x: 23-23
+s14x6: 20-20
+s14x7: 18-18
+s14x5: 22-22
+s14x15: 10-10
+s14x11: 28-28
+s14a1: 0-0
+s14x13: 32-32
+s14x8: 30-30
+s14x10: 29-29
+s14x9: 27-27
+s14x19: 3-3
+s14x20: 2-2
+s14x3: 15-15
+s14x12: 33-33
+
+# document level annotation:
+(s14s0 / sentence
+    :temporal ((document-creation-time :depends-on s14x24)
+            (s14x24 :before s14x6)
+            (s14x24 :overlap s14x11))
+    :modal ((root :modal author)
+            (author :full-affirmative s14x24)
+            (author :full-affirmative s14x6)
+            (author :full-affirmative s14x11)))
+
+
+################################################################################
+# meta-info
+# :: snt15
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
+Words: 王姓 药物 中介 不仅 进行 海外 药物 代购 ， 其 购买 胶囊 的 原因 也 是 为了 自行 配制 相关 药物 ， 二者 均 是 其 被捕 的 原因 ， 但 阿程 和 阿聪 等人 自杀 所 使用 的 化学品 却 仍然 能够 轻松 在 网上 买到
+
+# sentence level graph:
+(s15b / but-91
+    :op1 (s15a3 / and
+        :op1 (s15x / 进行-01
+            :ARG0 (s15i8 / individual-person
+                :op1 (s15c / clan
+                    :name (s15n / name
+                        :op1 "王"))
+                :ARG1-of (s15h3 / have-org-role-91
+                    :ARG3 (s15x20 / 中介
+                        :mod (s15x21 / 药物))))
+            :ARG1 (s15x5 / 代购
+                :ARG1 (s15x6 / 药物
+                    :place (s15x19 / 海外)))
+            :mod (s15x4 / 不仅)
+            :aspect performance)
+        :op2 (s15x22 / 购买-01
+            :ARG0 (s15x23 / 其)
+            :ARG1 (s15x24 / 胶囊)
+            :reason (s15x25 / 配制-01
+                :ARG1 (s15x3 / 药物
+                    :mod (s15x7 / 相关))
+                :mod (s15x2 / 自行)
+                :aspect performance)
+            :aspect performance)
+        :op3 (s15x8 / 是-01
+            :ARG0 (s15x26 / 二者)
+            :ARG1 (s15x16 / 原因
+                :mod (s15x18 / 被捕-01
+                    :ARG0 (s15x27 / 其-)
+                    :aspect performance))
+            :mod (s15x17 / 均)
+            :aspect performance))
+    :op2 (s15x28 / 买到-01
+        :ARG0 (s15a / and
+            :op1 (s15i2 / individual-person
+                :name (s15n2 / name
+                    :op1 "阿程"))
+            :op2 (s15i3 / individual-person
+                :name (s15n3 / name
+                    :op1 "阿聪"))
+            :op3 (s15x11 / 等人))
+        :ARG1 (s15x12 / 化学品
+            :ARG1-of (s15x10 / 使用-01
+                :ARG0 s15a
+                :ARG2 (s15x9 / 自杀-01
+                    :ARG0 s15a
+                    :aspect performance)
+                :aspect performance))
+        :mod (s15x14 / 轻松)
+        :place (s15x15 / 网上)
+        :mod (s15x13 / 仍然
+            :mod (s15x29 / 却))
+        :aspect state))
+
+# alignment:
+s15b: 0-0
+s15a3: 0-0
+s15x: 5-5
+s15i8: 0-0
+s15c: 0-0
+s15n: 0-0
+s15h3: 0-0
+s15x20: 3-3
+s15x5: 8-8
+s15x19: 6-6
+s15x4: 4-4
+s15x22: 11-11
+s15x24: 12-12
+s15x25: 19-19
+s15x7: 20-20
+s15x2: 18-18
+s15x26: 23-23
+s15x18: 27-27
+s15x17: 24-24
+s15x28: 47-47
+s15a: 0-0
+s15i2: 32-32
+s15n2: 0-0
+s15i3: 34-34
+s15n3: 0-0
+s15x11: 35-35
+s15x12: 40-40
+s15x10: 38-38
+s15x9: 36-36
+s15x14: 44-44
+s15x15: 46-46
+s15x13: 42-42
+s15x29: 41-41
+s15x21: 7-7
+s15x6: 2-2
+s15x23: 10-10
+s15x3: 21-21
+s15x8: 25-25
+s15x16: 29-29
+s15x27: 26-26
+
+# document level annotation:
+(s15s0 / sentence
+    :temporal ((document-creation-time :depends-on s15x)
+            (s15x :overlap s15x22)
+            (s15x22 :after s15x25)
+            (s15x25 :after s15x8)
+            (document-creation-time :depends-on s15x9)
+            (s15x9 :overlap s15x10)
+            (s15x28 :contained s15x10))
+    :modal ((root :modal author)
+            (author :full-affirmative s15x)
+            (author :full-affirmative s15x22)
+            (author :full-affirmative s15x25)
+            (author :full-affirmative s15x8)
+            (author :full-affirmative s15x9)
+            (author :full-affirmative s15x10)
+            (author :full-affirmative s15x28)
+            (author :full-affirmative s15x18)
+            (author :neutral-affirmative s15x28))
+    :coref ((s15i8 :same-entity s15x23)
+            (s15i8 :same-entity s15x27)))
+
+

--- a/chinese/umr_data/chinese_umr-0028.umr
+++ b/chinese/umr_data/chinese_umr-0028.umr
@@ -1,0 +1,633 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+Words: 16 : 9 的 屏幕 比例 、 21.5 英寸 宽屏 ， 它 的 最佳 分辨率 为 1920 × 1080 ，
+
+# sentence level graph:
+(s1x / and
+    :op1 (s1i1 / identity-91
+        :ARG2 (s1x6 / 1920×1080)
+        :ARG1 (s1x2 / 分辨率
+            :possessor (s1t / thing
+                :refer-number singular)
+            :mod (s1x1 / 最佳)))
+    :op2 (s1x8 / 比例
+        :possessor (s1x4 / 屏幕
+            :possessor s1t
+        :ARG1-of (s1i / identity-91
+            :ARG2 (s1s / percentage-entity)
+                :value 177)
+    :op1 (s1x5 / 宽屏
+        :possessor s1t
+        :mod (s1x12 / distance-quantity
+            :quant 21.5
+            :unit (s1x13 / 英寸))))))
+
+# alignment:
+s1x: 0-0
+s1i1: 0-0
+s1x2: 15-15
+s1t: 0-0
+s1x1: 14-14
+s1x8: 6-6
+s1x4: 5-5
+s1i: 0-0
+s1s: 0-0
+s1x5: 10-10
+s1x12: 0-0
+s1x13: 9-9
+s1x6: 17-17
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((document-creation-time :overlap s1i1))
+    :modal ((root :modal author)
+            (author :full-affirmative s1i1)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+Words: 而且 它 还 配备 了 D-Sub （ VGA ） ， HDMI 两 种 接口 ，
+
+# sentence level graph:
+(s2x / and
+    :op1 (s2x1 / 配备-01
+        :ARG0 (s2t / thing
+            :refer-number singular)
+        :mod (s2x2 / 还)
+        :ARG1 (s2x3 / 接口
+            :ARG1-of (s2i / identity-91
+                :ARG2 (s2x6 / and
+                    :op1 (s2x7 / D-Sub
+                        :ARG1-of (s2x8 / identity-91
+                            :ARG2 (s2x9 / VGA)))
+                    :op2 (s2x10 / HDMI)))
+            :quant 2
+            :unit (s2x4 / 种)))
+    :aspect performance)
+
+# alignment:
+s2x: 0-0
+s2x1: 4-4
+s2t: 0-0
+s2x2: 3-3
+s2x3: 14-14
+s2i: 0-0
+s2x6: 0-0
+s2x7: 6-6
+s2x8: 0-0
+s2x9: 8-8
+s2x10: 11-11
+s2x4: 13-13
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((document-creation-time :overlap s2x1))
+    :modal ((root :modal author)
+            (author :full-affirmative s2x1)
+            (author :full-affirmative s2x))
+    :coref ((s1t :same-entity s2t)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+Words: 能够 在 拨接 电脑 设备 之 余 ， 还 能够 方便 用户 进行 PS3 、 Xbox360 、 蓝光机 等等 设备 的 连接 。
+
+# sentence level graph:
+(s3x / and
+    :op1 (s3x8 / 方便-01
+        :ARG1 (s3x17 / 用户)
+        :ARG2 (s3x10 / 连接-01
+            :ARG1 (s3x11 / 设备
+                :example (s3x12 / and
+                    :op1 (s3x15 / PS3)
+                    :op2 (s3x16 / Xboa1660)
+                    :op3 (s3x13 / 蓝光机)
+                    :op4 (s3x14 / 等等)))
+            :aspect state)
+        :aspect state)
+    :op2 (s3x3 / 拨接-01
+        :aspect state
+        :ARG1 (s3x4 / 设备
+            :ARG1-of (s3i / identity-91
+                :ARG2 (s3x5 / 电脑)))))
+
+# alignment:
+s3x: 0-0
+s3x8: 11-11
+s3x17: 12-12
+s3x10: 22-22
+s3x12: 0-0
+s3x15: 14-14
+s3x16: 0-0
+s3x13: 18-18
+s3x14: 19-19
+s3x3: 3-3
+s3i: 0-0
+s3x5: 4-4
+s3x11: 20-20
+s3x4: 5-5
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((document-creation-time :overlap s3x3)
+            (s3x3 :overlap s3x8)
+            (s3x8 :overlap s3x10))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x3)
+            (author :full-affirmative s3x8)
+            (author :full-affirmative s3x10)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10
+Words: 这 就 是 三星 B560 ， 你 值得 拥有 !
+
+# sentence level graph:
+(s4x / and
+    :op1 (s4x2 / identity-91
+        :ARG1 (s4t / thing
+            :mod (s4x4 / 这)
+            :refer-number singular)
+        :ARG2 (s4p / product
+                  :name (s4n / name :op1 "三星" :op2 "B560"))
+        :aspect state
+        :mod (s4x7 / 就))
+    :op2 (s4x8 / 值得-01
+        :ARG0 (s4x9 / individual-person
+            :refer-person 2nd
+            :refer-number singular)
+        :ARG1 (s4x10 / 拥有-01
+            :ARG1 s4t
+            :ARG0 s4x9
+            :aspect state)
+        :mode expressive
+        :aspect state))
+
+# alignment:
+s4x: 0-0
+s4x2: 0-0
+s4t: 0-0
+s4x4: 1-1
+s4p: 4-5
+s4n: 0-0
+s4x7: 2-2
+s4x8: 8-8
+s4x9: 0-0
+s4x10: 9-9
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((document-creation-time :overlap s4x2)
+            (s4x2 :overlap s4x8)
+            (s4x8 :overlap s4x10))
+    :modal ((root :modal author)
+            (author :full-affirmative s4x2)
+            (author :full-affirmative s4x8)
+            (author :neutral-affirmative s4x10))
+    :coref ((s2t :same-entity s4t)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+Words: 方形 机身 和 方形 的 底座 设计 ， 笔挺 的 立姿 ， 有点 像 大师 打座 的 气势 。
+
+# sentence level graph:
+(s5x / 像-01
+    :degree (s5x13 / 有点)
+    :ARG1 (s5x10 / 气势
+        :mod (s5x11 / 打坐-01
+            :ARG0 (s5x12 / 大师)
+            :aspect state))
+    :aspect state
+    :ARG0 (s5x2 / and
+        :op1 (s5x1 / 立姿
+            :mod (s5x3 / 笔挺))
+        :op2 (s5x7 / 设计
+            :ARG1-of (s5i / identity-91
+                :ARG2 (s5a / and
+                    :op1 (s5x8 / 底座
+                        :mod (s5x9 / 方形))
+                    :op2 (s5x5 / 机身
+                        :mod (s5x6 / 方形)))))))
+
+# alignment:
+s5x: 14-14
+s5x13: 13-13
+s5x10: 18-18
+s5x11: 0-0
+s5x12: 15-15
+s5x2: 0-0
+s5x1: 11-11
+s5x3: 9-9
+s5x7: 7-7
+s5i: 0-0
+s5a: 0-0
+s5x8: 6-6
+s5x5: 2-2
+s5x9: 4-4
+s5x6: 1-1
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((document-creation-time :overlap s5x)
+            (s5x :overlap s5x11))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x11)
+            (author :partial-affirmative s5x)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+Words: 它 有 三 个 接口 ， 分别 为 电源 、 HDMI 、 VGA 。
+
+# sentence level graph:
+(s6x / and
+    :op1 (s6e / exist-91
+        :aspect state
+        :ARG2 (s6x3 / 接口
+            :quant 3
+            :unit (s6x4 / 个))
+        :ARG1 (s6p / thing
+            :refer-number singular))
+    :op2 (s6x6 / identity-91
+        :mod (s6x10 / 分别)
+        :ARG1 s6x3
+        :ARG2 (s6x8 / and
+            :op1 (s6x9 / 电源)
+            :op2 (s6x11 / VGA)
+            :op3 (s6x12 / HDMI))
+        :aspect state))
+
+# alignment:
+s6x: 0-0
+s6e: 0-0
+s6x3: 5-5
+s6x4: 4-4
+s6p: 0-0
+s6x6: 0-0
+s6x10: 7-7
+s6x8: 0-0
+s6x9: 9-9
+s6x11: 13-13
+s6x12: 11-11
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((document-creation-time :overlap s6e)
+            (s6e :overlap s6x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s6e)
+            (author :full-affirmative s6x6))
+    :coref ((s4p :same-entity s6p)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39
+Words: 高清 的 HDMI 接口 成为 现在 市场 的 主流 ， 很 有 可能 HDMI 就 是 2012 的 一 个 趋势 ， 同时 还 保留 有 VGA 的 接口 ， 让 消费者 在 不同 需求 上 得到 满足 。
+
+# sentence level graph:
+(s7x / and
+    :op1 (s7x22 / 成为-01
+        :ARG0 (s7x26 / 接口
+            :mod (s7x27 / 高清)
+            :mod (s7x28 / HDMI))
+        :ARG1 (s7x23 / 主流
+            :temporal (s7x25 / 现在)
+            :place (s7x24 / 市场))
+        :aspect performance)
+    :op2 (s7i / identity-91
+        :aspect state
+        :mod (s7x19 / 就)
+        :ARG2 (s7x17 / 趋势
+            :unit (s7x18 / 个)
+            :quant 1
+            :temporal (s7x20 / date-entity
+                :year 2012))
+        :ARG1 s7x28)
+    :op3 (s7x2 / 保留-01
+        :purpose (s7x9 / 满足-01
+            :ARG2 (s7x12 / 消费者)
+            :ARG1 (s7x10 / 需求
+                :mod (s7x1 / 不同))
+            :aspect state)
+        :ARG1 (s7x3 / 接口
+            :ARG1-of (s7i1 / identity-91
+                :ARG2 (s7x4 / VGA)))
+        :mod (s7x5 / 还)
+        :temporal (s7x6 / 同时)
+        :aspect performance))
+
+# alignment:
+s7x: 0-0
+s7x22: 5-5
+s7x27: 1-1
+s7x23: 9-9
+s7x25: 6-6
+s7x24: 7-7
+s7i: 0-0
+s7x19: 15-15
+s7x17: 21-21
+s7x18: 20-20
+s7x20: 0-0
+s7x2: 25-25
+s7x9: 38-38
+s7x12: 32-32
+s7x10: 35-35
+s7x1: 34-34
+s7i1: 0-0
+s7x4: 27-27
+s7x5: 24-24
+s7x6: 23-23
+s7x26: 4-4
+s7x28: 3-3
+s7x3: 29-29
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((document-creation-time :before s7x22)
+            (s7x22 :overlap s7i)
+            (s7x2 :after s7x9)
+            (document-creation-time :before s7x2))
+    :modal ((root :modal author)
+            (author :full-affirmative s7x22)
+            (author :strong-partial-affirmative s7i)
+            (author :full-affirmative s7x9)
+            (author :full-affirmative s7x2)
+            (author :partial-affirmative s7i)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+Words: 福韵 B560 系列 的 诠释 有 ： “ 福运 ” 、 “ 幸福 ” 、 和 拥有 贵族 的 “ 韵 ” 味 。
+
+# sentence level graph:
+(s8x / include-91
+    :aspect state
+    :ARG2 (s8x2 / and
+        :op1 (s8x3 / 福运)
+        :op2 (s8x7 / 幸福)
+        :op3 (s8x4 / 韵味
+            :mod (s8x5 / 贵族)
+            :ARG1-of (s8x6 / 拥有-01
+                :aspect state)))
+    :ARG1 (s8x1 / 诠释)
+        :possessor (s8x9 / 系列
+            :name (s8x10 / name
+                :op1 "福韵"
+                :op2 "B560")))
+
+# alignment:
+s8x: 0-0
+s8x2: 0-0
+s8x3: 9-9
+s8x7: 13-13
+s8x5: 18-18
+s8x6: 17-17
+s8x1: 5-5
+s8x9: 1-2
+s8x10: 0-0
+s8x4: 21-21
+
+# document level annotation:
+(s8s0 / sentence
+    :temporal ((document-creation-time :overlap s8x)
+            (s8x :overlap s8x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s8x)
+            (author :full-affirmative s8x6)
+            (author :full-affirmative s8x1))
+    :coref ((s6p :same-entity s8x9)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38
+Words: 左右上角 的 两 条 龙 设计 的 毫 无 瑕疵 ， 机身 背后 写 有 一 个 大大 的 “ 福 ” 字 ， 并且 拥有 古代 龙纹 图案 ， 这些 都 有 浓郁 的 中国 元素 。
+
+# sentence level graph:
+(s9x / and
+    :op1 (s9x1 / 设计-01
+        :mod (s9e / exist-91
+            :aspect state
+            :polarity -
+            :ARG2 (s9x22 / 瑕疵))
+        :ARG1 (s9x26 / 龙
+            :place (s9x25 / 左右上角)
+            :unit (s9x27 / 条)
+            :quant 2))
+    :op2 (s9x2 / 写-01
+        :aspect state
+        :ARG1 (s9x3 / 字
+            :mod (s9x5 / 大大)
+            :quant 1
+            :unit (s9x6 / 个)
+            :ARG1-of (s9i / identity-91
+                :ARG2 (s9x4 / 福)))
+        :ARG2 (s9x7 / 背后
+            :part (s9x8 / 机身)))
+    :op3 (s9e1 / exist-91
+        :aspect state
+        :ARG2 (s9x18 / 图案
+            :mod (s9x19 / 古代)
+            :mod (s9x20 / 龙纹)))
+    :op4 (s9h / have-91
+        :aspect state
+        :ARG1 (s9a / and
+            :op1 s9x3
+            :op2 s9x26
+            :op3 s9x18)
+        :ARG2 (s9x10 / 元素
+            :mod (s9x11 / 浓郁)
+            :mod (s9x12 / country
+                :name (s9x13 / name
+                    :op1 "中国")))
+        :mod (s9x16 / 都)))
+
+# alignment:
+s9x: 0-0
+s9x1: 6-6
+s9e: 0-0
+s9x22: 10-10
+s9x26: 5-5
+s9x25: 1-1
+s9x27: 4-4
+s9x2: 14-14
+s9x3: 23-23
+s9x5: 18-18
+s9x6: 17-17
+s9i: 0-0
+s9x4: 21-21
+s9x7: 13-13
+s9x8: 12-12
+s9e1: 0-0
+s9x18: 29-29
+s9x19: 27-27
+s9x20: 28-28
+s9h: 0-0
+s9a: 0-0
+s9x10: 37-37
+s9x11: 34-34
+s9x12: 36-36
+s9x13: 0-0
+s9x16: 32-32
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((document-creation-time :before s9x1)
+            (document-creation-time :before s9x2)
+            (document-creation-time :before s9e1)
+            (document-creation-time :overlap s9h))
+    :modal ((root :modal author)
+            (author :full-affirmative s9x1)
+            (author :full-affirmative s9x2)
+            (author :full-affirmative s9e1)
+            (author :full-affirmative s9h)
+            (author :full-affirmative s9e)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
+Words: 金黄色 的 B560 系列 看 起来 更 符合 龙年 的 韵味 ， 背部 的 福 字 也 更加 现眼 . 。
+
+# sentence level graph:
+(s10x / and
+    :op1 (s10x1 / 看-04
+        :aspect state
+        :ARG0 (s10x9 / 符合-01
+            :degree (s10x10 / 更)
+            :ARG1 (s10x11 / 韵味
+                :mod (s10x12 / 龙年))
+            :aspect state)
+        :ARG0 (s10x13 / 系列
+            :name (s10x14 / name
+                :op1 "B560")
+            :mod (s10x15 / 金黄色)))
+    :op2 (s10x2 / 显眼-01
+        :ARG0 (s10x3 / 字
+            :ARG1-of (s10i / identity-91
+                :ARG2 (s10x4 / 福))
+            :place (s10x5 / 背部))
+        :mod (s10x7 / 也)
+        :degree (s10x6 / 更加)
+        :aspect state))
+
+# alignment:
+s10x: 0-0
+s10x1: 5-5
+s10x9: 8-8
+s10x10: 7-7
+s10x11: 11-11
+s10x12: 9-9
+s10x13: 4-4
+s10x14: 0-0
+s10x15: 1-1
+s10x2: 0-0
+s10x3: 16-16
+s10i: 0-0
+s10x4: 15-15
+s10x5: 13-13
+s10x7: 17-17
+s10x6: 18-18
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((document-creation-time :overlap s10x1)
+            (s10x1 :overlap s10x9)
+            (s10x1 :overlap s10x2))
+    :modal ((root :modal author)
+            (author :full-affirmative s10x1)
+            (author :full-affirmative s10x9)
+            (author :full-affirmative s10x2))
+    :coref ((s8x9 :same-entity s10x13)))
+
+
+################################################################################
+# meta-info
+# :: snt11
+Index: 1 2 3 4 5 6 7 8 9 10
+Words: 中国人 的 习俗 ， 把 龙 当做 为 吉祥物 。
+
+# sentence level graph:
+(s11x / identity-91
+    :ARG2 (s11x4 / 当做-01
+        :ARG1 (s11x6 / 龙)
+        :ARG2 (s11x5 / 吉祥物)
+        :aspect state)
+    :ARG1 (s11x2 / 习俗
+        :possessor (s11p / person
+            :mod (s11c / country
+                     :name (s11n / name :op1 "中国"))
+            :refer-number plural)))
+
+# alignment:
+s11x: 0-0
+s11x4: 7-7
+s11x6: 6-6
+s11x5: 9-9
+s11x2: 3-3
+s11p: 0-0
+s11c: 0-0
+s11n: 0-0
+
+# document level annotation:
+(s11s0 / sentence
+    :temporal ((document-creation-time :overlap s11x4))
+    :modal ((root :modal author)
+            (author :full-affirmative s11x4)))
+
+
+################################################################################
+# meta-info
+# :: snt12
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+Words: 在 龙年 快 要 到来 之 时 还 不 赶快 把 “ 福韵 ” 带 回家 ！
+
+# sentence level graph:
+(s12x / 带-02
+    :temporal (s12x4 / 到来-01
+        :aspect state
+        :ARG0 (s12x5 / 龙年)
+        :manner (s12x6 / 快))
+    :mode expressive
+    :aspect state
+    :manner (s12x2 / 赶快)
+    :ARG3 (s12x7 / 回家)
+    :ARG1 (s12x8 / 福韵))
+
+# alignment:
+s12x: 15-15
+s12x4: 5-5
+s12x5: 2-2
+s12x6: 3-3
+s12x2: 10-10
+s12x7: 16-16
+s12x8: 13-13
+
+# document level annotation:
+(s12s0 / sentence
+    :temporal ((document-creation-time :after s12x)
+            (document-creation-time :after s12x4))
+    :modal ((root :modal author)
+            (author :full-affirmative s12x4)
+            (author :neutral-affirmative s12x)))
+
+

--- a/chinese/umr_data/chinese_umr-0029.umr
+++ b/chinese/umr_data/chinese_umr-0029.umr
@@ -1,0 +1,1385 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 形象 大 受 伤害 的 “ 市政府 ” 相关 机构 ， 应该 出面 调查 这 件 事情 的 真伪 ， 并 公布 相关 结果 。
+
+# sentence level graph:
+(s1a1 / and
+    :op1 (s1x3 / 公布-01
+        :ARG1 (s1x4 / 结果
+            :mod (s1x5 / 相关))
+        :ARG0 s1x6
+        :aspect state)
+    :op2 (s1x7 / 出面-01
+        :aspect state
+        :ARG1 (s1x / 调查-01
+            :aspect state
+            :ARG1 (s1x18 / 真伪
+                :possessor (s1x19 / 事情
+                    :unit (s1x20 / 件)
+                    :mod (s1x21 / 这))))
+        :ARG0 (s1x6 / 机构
+            :possessor-of (s1x1 / 形象
+                :ARG1-of (s1x2 / 伤害-01
+                    :aspect performance)
+                    :degree (s1x15 / 大))
+            :mod (s1x8 / 相关)
+            :ARG1-of (s1x9 / identity-91
+                :ARG2 (s1x10 / government-organization
+                    :name (s1x11 / name
+                        :op1 "市政府"))))))
+
+# alignment:
+s1a1: 0-0
+s1x3: 22-22
+s1x4: 24-24
+s1x7: 13-13
+s1x: 14-14
+s1x18: 19-19
+s1x19: 17-17
+s1x20: 16-16
+s1x21: 15-15
+s1x6: 10-10
+s1x1: 1-1
+s1x2: 4-4
+s1x15: 2-2
+s1x9: 0-0
+s1x10: 7-7
+s1x11: 0-0
+s1x5: 23-23
+s1x8: 9-9
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((document-creation-time :before s1x2)
+            (s1x2 :after s1x7)
+            (s1x7 :after s1x)
+            (s1x :after s1x3))
+    :modal ((author :full-affirmative s1x2)
+            (author :partial-affirmative s1x7)
+            (author :partial-affirmative s1x)
+            (root :modal author)
+            (author :partial-affirmative s1x3)
+            (author :partial-affirmative s1x6)
+            (author :full-affirmative s1x1)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+Words: 近日 ， 一 名 上海 网友 在 微博 上 晒出 自己 老公 年终 发放 的 各 种 提货券 、 食品券 ， 大 赞 “ 市政府 真 给力 ” ， 该 微博 瞬间 引起 轩然大波 ， 过 10万 网友 围观 。
+
+# sentence level graph:
+(s2x / and
+     :op1 (s2x2 / 引起-01
+               :temporal (s2x3 / 瞬间)
+               :ARG0 (s2x4 / 微博
+                          :mod (s2x5 / 该))
+               :ARG1 (s2x6 / 轩然大波)
+               :aspect performance)
+     :temporal (s2x7 / 近日)
+     :op2 (s2x8 / 围观-01
+               :ARG1 s2x4
+               :ARG0 (s2x10 / 网友
+                         :quant (s2x11 / 过
+                                     :op1 100000))
+               :aspect performance)
+     :op3 (s2x13 / 赞-01
+              :degree (s2x14 / 大)
+              :ARG0 (s2x15 / 网友
+                  :mod (s2c / country-region
+                           :name (s2n / name :op1 "上海"))
+                  :possessor-of (s2x1 / 老公)
+                  :unit (s2x18 / 名)
+                  :quant 1)
+              :ARG1 (s2x21 / 给力-00
+                         :degree (s2x22 / 真)
+                         :ARG0 (s2x23 / government-organization
+                                    :name (s2x24 / name
+                                               :op1 "市政府")))
+              :aspect performance)
+     :op4 (s2x17 / 晒出-01
+               :aspect performance
+               :ARG0 s2x15
+               :ARG1 (s2x26 / and
+                   :op1 (s2x32 / 食品券)
+                   :op2 (s2x27 / 提货券)
+                   :unit (s2x31 / 种)
+                   :mod (s2x33 / 各)
+                   :ARG1-of (s2x28 / 发放-01
+                       :aspect performance
+                       :ARG2 s2x1
+                       :temporal (s2x30 / 年终)))
+               :place (s2x34 / 微博)))
+
+# alignment:
+s2x: 0-0
+s2x2: 33-33
+s2x3: 32-32
+s2x5: 30-30
+s2x6: 34-34
+s2x7: 1-1
+s2x8: 39-39
+s2x11: 36-36
+s2x13: 23-23
+s2x14: 22-22
+s2c: 5-5
+s2n: 0-0
+s2x1: 12-12
+s2x18: 4-4
+s2x21: 27-27
+s2x22: 26-26
+s2x23: 25-25
+s2x24: 0-0
+s2x17: 10-10
+s2x26: 0-0
+s2x32: 20-20
+s2x27: 18-18
+s2x31: 17-17
+s2x33: 16-16
+s2x28: 14-14
+s2x30: 13-13
+s2x4: 31-31
+s2x10: 38-38
+s2x15: 6-6
+s2x34: 8-8
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((document-creation-time :depends-on s2x7)
+            (s2x7 :contained s2x17)
+            (s2x7 :contained s2x28)
+            (s2x7 :contained s2x13)
+            (s2x7 :contained s2x21)
+            (s2x7 :contained s2x2)
+            (s2x7 :contained s2x8)
+            (s2x17 :before s2x28)
+            (s2x17 :after s2x13)
+            (s2x13 :before s2x21)
+            (s2x13 :after s2x2)
+            (s2x2 :after s2x8))
+    :modal ((author :full-affirmative s2x17)
+            (author :full-affirmative s2x28)
+            (author :full-affirmative s2x13)
+            (author :full-affirmative s2x15)
+            (s2x15 :full-affirmative s2x21)
+            (author :full-affirmative s2x2)
+            (author :full-affirmative s2x8)
+            (root :modal author))
+    :coref ((s1x19 :same-event s2x28)
+            (s1x10 :same-entity s2x23)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43
+Words: 该 名 网友 接受 采访 时 解释 称 ， 自己 因为 “ 无聊 ” 才 虚构 出 这些 信息 ， 微博 上 的 “ 老公 ” 是 前 男友 ， 现 已 分手 。 （ 据 1月 18日 《 成都 晚报 》 ）
+
+# sentence level graph:
+(s3x / 解释-01
+    :aspect performance
+    :temporal (s3x2 / 接受-01
+                    :ARG1 (s3x3 / 采访)
+                    :aspect performance
+                    :ARG0 s3x4)
+     :ARG0 (s3x4 / 网友
+                :ARG0-of (s3x6 / 无聊-01
+                             :aspect performance)
+                :ARG0-of (s3x7 / 虚构-01
+                              :ARG1 (s3x8 / 信息
+                                         :mod (s3x9 / 这些))
+                              :cause s3x6
+                              :aspect performance
+                              :mod (s3x11 / 才))
+                :mod (s3x12 / 该)
+                :unit (s3x13 / 名))
+     :ARG3 (s3x14 / and
+                :op1 (s3x15 / 分手-01
+                         :ARG0 (s3x16 / and
+                             :op1 s3x22
+                             :op2 s3x4)
+                         :aspect performance
+                         :temporal (s3x20 / 现))
+                :op2 s3x7
+                :op3 (s3x22 / identity-91
+                    :aspect state
+                    :ARG1 (s3x1 / 老公
+                        :place (s3x5 / 微博))
+                    :ARG2 (s3x24 / 男友
+                        :mod (s3x25 / 前))))
+     :according-to (s3x26 / newspaper
+                        :temporal (s3x27 / date-entity
+                            :day 18
+                            :month 1)
+                        :name (s3x28 / name
+                                  :op1 "晚报"
+                                  :op2 "成都")))
+
+# alignment:
+s3x: 7-7
+s3x2: 4-4
+s3x3: 5-5
+s3x4: 3-3
+s3x6: 13-13
+s3x7: 16-16
+s3x8: 19-19
+s3x9: 18-18
+s3x11: 15-15
+s3x12: 1-1
+s3x13: 2-2
+s3x14: 0-0
+s3x15: 33-33
+s3x16: 0-0
+s3x20: 31-31
+s3x22: 0-0
+s3x1: 25-25
+s3x5: 21-21
+s3x24: 29-29
+s3x25: 28-28
+s3x26: 40-41
+s3x27: 0-0
+s3x28: 0-0
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((document-creation-time :before s3x2)
+            (s3x2 :after s3x3)
+            (s3x3 :after s3x)
+            (s3x2 :before s3x6)
+            (s3x6 :after s3x7)
+            (s3x2 :before s3x7)
+            (document-creation-time :overlap s3x22)
+            (s3x2 :before s3x15))
+    :modal ((author :full-affirmative s3x2)
+            (author :full-affirmative s3x3)
+            (author :full-affirmative s3x)
+            (author :full-affirmative s3x4)
+            (s3x4 :full-affirmative s3x6)
+            (s3x4 :full-affirmative s3x22)
+            (s3x4 :full-affirmative s3x7)
+            (s3x4 :full-affirmative s3x15)
+            (root :modal author)
+            (author :full-affirmative s3x6)
+            (author :full-affirmative s3x7)
+            (author :full-affirmative s3x15)
+            (author :full-affirmative s3x22))
+    :coref ((s2x15 :same-entity s3x4)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41
+Words: 这 是 继 引起 各 种 网络 风波 的 “ 美美 ” 之后 的 又 一 次 “ 晒 富 ” 事件 ， 虽然 晒 的 不 是 名车 豪宅 名包 奢侈品 ， 而 是 应时 应景 的 春节 提货券 ，
+
+# sentence level graph:
+(s4x / and
+    :op1 (s4x2 / identity-91
+        :aspect state
+        :ARG1 (s4t / thing
+            :mod (s4x1 / 这))
+        :ARG2 (s4x3 / 事件
+            :topic (s4x16 / 晒-04
+                :ARG1 (s4x17 / 富))
+            :quant 1
+            :mod (s4x4 / 又)
+            :unit (s4x5 / 次)
+            :temporal (s4x6 / 之后
+                :op1 (s4x7 / event
+                    :ARG0-of (s4x9 / 引起-01
+                        :aspect performance
+                        :ARG1 (s4x10 / 风波
+                            :mod (s4x11 / 网络)
+                            :unit (s4x12 / 种)
+                            :mod (s4x13 / 各)))
+                    :name (s4x8 / name
+                       :op1 "美美")))))
+    :op2 (s4x18 / contrast-91
+        :ARG2 (s4x19 / identity-91
+            :ARG1 (s4x20 / thing
+                :ARG1-of (s4x21 / 晒-04
+                    :aspect performance))
+            :ARG2 (s4x24 / 提货券
+                :ARG0-of (s4x22 / 应时-00)
+                :ARG0-of (s4x23 / 应景-01)
+                :mod (s4x25 / 春节)))
+        :aspect state
+        :ARG1 (s4x26 / identity-91
+            :ARG2 (s4x27 / and
+                :op1 (s4x28 / 名车)
+                :op2 (s4x29 / 奢侈品)
+                :polarity -
+                :op3 (s4x30 / 豪宅)
+                :op4 (s4x31 / 名包))
+            :ARG1 s4x20)))
+
+# alignment:
+s4x: 0-0
+s4x2: 0-0
+s4t: 0-0
+s4x1: 1-1
+s4x3: 22-22
+s4x17: 20-20
+s4x4: 15-15
+s4x5: 17-17
+s4x6: 13-13
+s4x7: 11-11
+s4x9: 4-4
+s4x10: 8-8
+s4x11: 7-7
+s4x12: 6-6
+s4x13: 5-5
+s4x8: 0-0
+s4x18: 0-0
+s4x19: 0-0
+s4x20: 0-0
+s4x24: 40-40
+s4x22: 36-36
+s4x23: 37-37
+s4x25: 39-39
+s4x26: 0-0
+s4x27: 0-0
+s4x28: 29-29
+s4x29: 32-32
+s4x30: 30-30
+s4x31: 31-31
+s4x16: 19-19
+s4x21: 25-25
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((document-creation-time :before s4x9)
+            (s4x9 :after s4x16)
+            (s4x16 :after s4x21))
+    :modal ((author :full-affirmative s4x9)
+            (author :full-affirmative s4x16)
+            (author :full-affirmative s4x21)
+            (root :modal author)
+            (author :full-affirmative s4x2)
+            (author :full-affirmative s4x18))
+    :coref ((s2x17 :same-event s4x3)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+Words: 但 此 事 发生 在 春节 前夕 ， 许多 人 正在 置办 年货 ，
+
+# sentence level graph:
+(s5x / contrast-91
+    :aspect performance
+    :ARG2 (s5x2 / and
+              :op1 (s5x3 / 置办-01
+                       :aspect performance
+                       :ARG0 (s5x4 / 人
+                                 :quant (s5x5 / 许多))
+                       :ARG1 (s5x6 / 年货))
+              :op2 (s5x7 / 发生-01
+                       :ARG0 (s5x8 / 事
+                                 :mod (s5x9 / 此))
+                       :temporal (s5x10 / 前夕
+                                     :op1 (s5x11 / 春节))
+                       :aspect performance)))
+
+# alignment:
+s5x: 0-0
+s5x2: 0-0
+s5x3: 12-12
+s5x4: 10-10
+s5x5: 9-9
+s5x6: 13-13
+s5x7: 4-4
+s5x8: 3-3
+s5x9: 2-2
+s5x10: 7-7
+s5x11: 6-6
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((document-creation-time :depends-on s5x10)
+            (s5x10 :contained s5x7)
+            (s5x10 :contained s5x3))
+    :modal ((author :full-affirmative s5x3)
+            (author :full-affirmative s5x7)
+            (root :modal author)
+            (author :full-affirmative s5x))
+    :coref ((s4x3 :same-event s5x8)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
+Words: 某些 人 甚至 因 年货 的 价格 与 年终奖 的 数字 不 匹配 而 正 郁闷 的 时候 ， 其 受 关注 度 就 可想而知 了 。
+
+# sentence level graph:
+(s6x / 可想而知-01
+    :aspect state
+    :mod (s6x2 / 就)
+    :temporal (s6x3 / 郁闷-01
+                   :aspect activity
+                   :mod (s6x4 / 甚至)
+                   :ARG0 (s6x5 / 人
+                              :mod (s6x6 / 某些))
+                   :cause (s6x7 / 匹配-01
+                              :polarity -
+                              :ARG0 (s6x8 / and
+                                         :op1 (s6x9 / 价格
+                                             :possessor (s6x1 / 年货))
+                                         :op2 (s6x11 / 数字
+                                             :possessor (s6x18 / 年终奖)))
+                              :aspect performance))
+    :ARG0 (s6x14 / 度
+              :mod (s6x15 / 其)
+              :mod (s6x16 / 受-02
+                        :ARG1 (s6x17 / 关注)
+                        :aspect activity)))
+
+# alignment:
+s6x: 25-25
+s6x2: 24-24
+s6x3: 16-16
+s6x4: 3-3
+s6x5: 2-2
+s6x6: 1-1
+s6x7: 13-13
+s6x8: 0-0
+s6x9: 7-7
+s6x1: 5-5
+s6x11: 11-11
+s6x18: 9-9
+s6x14: 23-23
+s6x15: 20-20
+s6x16: 21-21
+s6x17: 22-22
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((document-creation-time :before s6x7)
+            (s6x7 :after s6x3)
+            (s6x3 :after s6x16)
+            (s6x16 :after s6x))
+    :modal ((author :full-negative s6x7)
+            (author :full-affirmative s6x3)
+            (author :full-affirmative s6x)
+            (author :full-affirmative s6x16)
+            (root :modal author))
+    :coref ((s5x8 :same-event s6x15)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+Words: 可能 连 心理学家 都 搞 不 明白 ， 这 位 网友 此 举 的 动机 到底 是 什么 ？
+
+# sentence level graph:
+(s7x1 / 明白-01
+    :aspect state
+    :mode interrogative
+    :polarity umr-unknown
+    :ARG1 (s7x2 / 动机
+        :possessor (s7x3 / 举
+            :possessor (s7x5 / 网友
+                :unit (s7x7 / 位)
+                :mod (s7x6 / 这))
+            :mod (s7x4 / 此))
+    :ARG0 (s7x / 心理学家)))
+
+# alignment:
+s7x1: 7-7
+s7x2: 15-15
+s7x3: 13-13
+s7x5: 11-11
+s7x7: 10-10
+s7x6: 9-9
+s7x4: 12-12
+s7x: 3-3
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((document-creation-time :depends-on s7x1))
+    :modal ((author :partial-negative s7x1)
+            (root :modal author)
+            (author :neutral-affirmative s7x1))
+    :coref ((s6x15 :same-event s7x3)
+            (s3x4 :same-entity s7x5)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13
+Words: 从 微博 的 字面 上 来 看 ， 有 几 种 可能性 ：
+
+# sentence level graph:
+(s8x / 看-02
+    :aspect activity
+    :ARG1 (s8x1 / 可能性
+        :ARG1-of (s8x4 / 有-01
+            :aspect state)
+        :quant (s8x5 / 几)
+        :unit (s8x8 / 种))
+    :source (s8x6 / 字面
+        :possessor (s8x2 / 微博)))
+
+# alignment:
+s8x: 7-7
+s8x1: 12-12
+s8x4: 9-9
+s8x5: 10-10
+s8x8: 11-11
+s8x6: 4-4
+s8x2: 2-2
+
+# document level annotation:
+(s8s0 / sentence
+    :temporal ((document-creation-time :depends-on s8x)
+            (s8x :after s8x4))
+    :modal ((author :full-affirmative s8x)
+            (author :full-affirmative s8x4)
+            (root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22
+Words: 第一 ， 如同 其他 一些 喜欢 晒 奢侈品 的 女人 那样 ， 是 虚荣心 作怪 ， 希望 得到 众人 的 羡慕 ；
+
+# sentence level graph:
+(s9x / identity-91
+    :aspect state
+    :ARG1 (s9x16 / thing
+        :ord (s9x17 / ordinal-entity
+            :value 1))
+    :ARG2 (s9a / and
+        :op1 (s9x5 / 希望-01
+            :aspect state
+            :ARG1 (s9x6 / 得到-01
+                :aspect state
+                :ARG1 (s9x7 / 羡慕-01
+                    :aspect state
+                    :ARG0 (s9x8 / 众人))))
+        :op2 (s9x3 / 作怪-01
+            :aspect state
+            :ARG0 (s9x4 / 虚荣心))
+        :op3 (s9x1 / 如同
+            :aspect state
+            :ARG1 (s9x10 / 女人
+                :mod (s9x11 / 其他)
+                :ARG0-of (s9x12 / 喜欢-01
+                    :aspect state
+                    :ARG1 (s9x13 / 晒-04
+                        :aspect state
+                        :ARG1 (s9x14 / 奢侈品)))
+                :quant (s9x15 / 一些)))))
+
+# alignment:
+s9x: 0-0
+s9x16: 0-0
+s9x17: 0-0
+s9a: 0-0
+s9x5: 17-17
+s9x6: 18-18
+s9x7: 21-21
+s9x8: 19-19
+s9x3: 15-15
+s9x4: 14-14
+s9x1: 3-3
+s9x10: 10-10
+s9x11: 4-4
+s9x12: 6-6
+s9x13: 7-7
+s9x14: 8-8
+s9x15: 5-5
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((s9x1 :overlap s9x12)
+            (s9x12 :after s9x13)
+            (s9x13 :overlap s9x3)
+            (s9x3 :overlap s9x5)
+            (s9x5 :after s9x6)
+            (s9x6 :after s9x7)
+            (document-creation-time :overlap s9x)
+            (s9x :overlap s9x1))
+    :modal ((author :full-affirmative s9x12)
+            (author :full-affirmative s9x13)
+            (author :full-affirmative s9x7)
+            (author :full-affirmative s9x)
+            (author :partial-affirmative s9x1)
+            (author :partial-affirmative s9x3)
+            (author :partial-affirmative s9x5)
+            (author :partial-affirmative s9x6)
+            (root :modal author))
+    :coref ((s8x1 :same-entity s9x16)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39
+Words: 第二 种 可能 ， 是 某 一 种 带有 营销 目的 的 炒作 ， 以 刺激 社会 最 敏感 的 神经 ， 来 激起 人们 的 反感 ， 用 “ 找抽 ” 的 方式 换取 点击率 和 关注度 ；
+
+# sentence level graph:
+(s10x / identity-91
+    :aspect state
+    :ARG2 (s10x1 / 炒作
+        :aspect state
+        :quant 1
+        :unit (s10x3 / 种)
+        :mod (s10x4 / 某)
+        :ARG0-of (s10x5 / 带有-01
+            :purpose (s10a / and
+                :op1 (s10x18 / 换取-01
+                    :aspect state
+                    :manner (s10x19 / 方式
+                        :mod (s10x20 / 找抽))
+                    :ARG1 (s10x21 / and
+                        :op1 (s10x22 / 点击率)
+                        :op2 (s10x23 / 关注度)))
+                :op2 (s10x10 / 激起-01
+                    :aspect state
+                    :ARG1 (s10x16 / 反感-01
+                        :ARG0 (s10x17 / 人们)
+                        :aspect state)
+                    :manner (s10x11 / 刺激-01
+                        :aspect state
+                        :ARG1 (s10x12 / 神经
+                            :possessor (s10x2 / 社会)
+                            :ARG0-of (s10x14 / 敏感-01
+                                :aspect state
+                                :degree (s10x15 / 最))))))
+            :aspect state
+            :ARG1 (s10x6 / 目的
+                :mod (s10x7 / 营销))))
+    :ARG1 (s10x24 / 可能
+        :ord (s10o / ordinal-entity
+            :value 2
+            :unit (s10x26 / 种))))
+
+# alignment:
+s10x: 0-0
+s10x1: 13-13
+s10x4: 6-6
+s10x5: 9-9
+s10a: 0-0
+s10x18: 35-35
+s10x19: 34-34
+s10x20: 31-31
+s10x21: 0-0
+s10x22: 36-36
+s10x23: 38-38
+s10x10: 24-24
+s10x16: 27-27
+s10x17: 25-25
+s10x11: 16-16
+s10x12: 21-21
+s10x2: 17-17
+s10x14: 19-19
+s10x15: 18-18
+s10x6: 11-11
+s10x7: 10-10
+s10x24: 3-3
+s10o: 0-0
+s10x3: 8-8
+s10x26: 2-2
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((document-creation-time :overlap s10x)
+            (s10x :overlap s10x5)
+            (s10x5 :overlap s10x7)
+            (s10x7 :overlap s10x1)
+            (s10x1 :after s10x11)
+            (s10x11 :overlap s10x14)
+            (s10x14 :after s10x10)
+            (s10x10 :after s10x16)
+            (s10x16 :after s10x18))
+    :modal ((author :full-affirmative s10x)
+            (author :partial-affirmative s10x5)
+            (author :partial-affirmative s10x1)
+            (author :partial-affirmative s10x11)
+            (author :full-affirmative s10x14)
+            (author :partial-affirmative s10x10)
+            (author :partial-affirmative s10x16)
+            (author :partial-affirmative s10x18)
+            (root :modal author))
+    :coref ((s9x16 :same-entity s10x24)))
+
+
+################################################################################
+# meta-info
+# :: snt11
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41
+Words: 第三 种 可能 ， 则 是 对 公务员 等 职业 有 偏见 ， 想 通过 一 种 “ 无间道 ” 的 方式 ， 表面 赞 “ 政府 给力 ” ， 其实 是 激发 众人 对 公务员 和 政府 的 不满 ；
+
+# sentence level graph:
+(s11x / identity-91
+    :aspect state
+     :ARG1 (s11x2 / 可能
+         :ord (s11x3 / ordinal-entity
+             :unit (s11x4 / 种)
+             :value 3))
+     :ARG2 (s11x5 / and
+         :op1 (s11x1 / 有偏见-00
+             :aspect state
+             :ARG1 (s11x10 / 职业)
+                 :example (s11a / and)
+                     :op1 (s11x8 / 公务员))
+         :op2 (s11x12 / 想-02
+             :aspect state
+             :ARG1 (s11x13 / and
+                 :op1 (s11x14 / 赞-01
+                     :ARG1 (s11x6 / 政府
+                         :ARG0-of (s11x7 / 给力-00
+                             :aspect state))
+                     :mod (s11x15 / 表面)
+                     :aspect state)
+                 :manner (s11x18 / 方式
+                     :unit (s11x19 / 种)
+                     :mod (s11x20 / 无间道)
+                     :quant 1)
+                 :op2 (s11x21 / 激发-01
+                     :aspect state
+                     :mod (s11x22 / 其实)
+                     :ARG1 (s11x23 / 不满-01
+                          :ARG1 (s11x24 / and
+                              :op1 (s11x25 / 政府)
+                              :op2 (s11x26 / 公务员))
+                          :ARG0 (s11x27 / 众人)
+                          :aspect state))))))
+
+# alignment:
+s11x: 0-0
+s11x2: 3-3
+s11x3: 0-0
+s11x5: 0-0
+s11x10: 10-10
+s11a: 0-0
+s11x12: 14-14
+s11x13: 0-0
+s11x14: 25-25
+s11x7: 28-28
+s11x15: 24-24
+s11x18: 22-22
+s11x20: 19-19
+s11x21: 33-33
+s11x22: 31-31
+s11x23: 40-40
+s11x24: 0-0
+s11x27: 34-34
+s11x4: 2-2
+s11x1: 11-11
+s11x8: 8-8
+s11x6: 27-27
+s11x19: 17-17
+s11x25: 38-38
+s11x26: 36-36
+
+# document level annotation:
+(s11s0 / sentence
+    :temporal ((document-creation-time :overlap s11x)
+            (s11x :overlap s11x1)
+            (s11x1 :after s11x12)
+            (s11x12 :after s11x14)
+            (document-creation-time :before s11x7)
+            (s11x14 :after s11x21)
+            (s11x21 :after s11x23))
+    :modal ((author :full-affirmative s11x)
+            (author :partial-affirmative s11x1)
+            (author :partial-affirmative s11x12)
+            (author :partial-affirmative s11x14)
+            (author :partial-affirmative s11x7)
+            (author :partial-affirmative s11x21)
+            (author :partial-affirmative s11x23)
+            (root :modal author)
+            (author :partial-affirmative s11x6))
+    :coref ((s10x24 :same-entity s11x2)))
+
+
+################################################################################
+# meta-info
+# :: snt12
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+Words: 第四 种 可能 ， 则 真 如 她 向 记者 解释 的 那样 ， 是 无聊 。
+
+# sentence level graph:
+(s12x / identity-91
+    :aspect state
+     :ARG1 (s12x2 / 可能
+               :ord (s12x3 / ordinal-entity
+                        :value 4
+                        :unit (s12x4 / 种)))
+     :ARG0-of (s12x5 / 如-01
+                  :ARG1 (s12x6 / thing
+                            :ARG3-of (s12x7 / 解释-01
+                                         :ARG0 (s12x8 / individual-person
+                                                   :refer-person 3rd
+                                                   :refer-number singular)
+                                         :ARG2 (s12x9 / 记者)
+                                         :aspect performance))
+                  :aspect state
+                  :mod (s12x10 / 真))
+     :ARG2 (s12x11 / 无聊-01
+               :aspect performance))
+
+# alignment:
+s12x: 0-0
+s12x2: 3-3
+s12x3: 0-0
+s12x4: 2-2
+s12x5: 7-7
+s12x6: 0-0
+s12x7: 11-11
+s12x8: 0-0
+s12x9: 10-10
+s12x10: 6-6
+s12x11: 16-16
+
+# document level annotation:
+(s12s0 / sentence
+    :temporal ((document-creation-time :overlap s12x)
+            (s12x :overlap s12x5)
+            (document-creation-time :before s12x7)
+            (s12x7 :before s12x11))
+    :modal ((author :full-affirmative s12x)
+            (author :partial-affirmative s12x5)
+            (author :full-affirmative s12x7)
+            (author :full-affirmative s12x8)
+            (s12x8 :full-affirmative s12x11)
+            (root :modal author)
+            (author :full-affirmative s12x11))
+    :coref ((s11x2 :same-entity s12x2)
+            (s7x5 :same-entity s12x8)))
+
+
+################################################################################
+# meta-info
+# :: snt13
+Index: 1 2 3 4 5 6 7 8 9 10 11 12
+Words: 以上 的 几 种 情况 ， 都 是 完全 可能 的 ——
+
+# sentence level graph:
+(s13x / 可能-01
+    :aspect state
+    :ARG0 (s13x2 / 情况
+              :mod (s13x4 / 以上)
+              :quant (s13x5 / 几)
+              :unit (s13x6 / 种))
+    :mod (s13x3 / 都)
+    :degree (s13x7 / 完全))
+
+# alignment:
+s13x: 10-10
+s13x2: 5-5
+s13x4: 1-1
+s13x5: 3-3
+s13x6: 4-4
+s13x3: 7-7
+s13x7: 9-9
+
+# document level annotation:
+(s13s0 / sentence
+    :temporal ((document-creation-time :overlap s13x))
+    :modal ((author :neutral-affirmative s13x)
+            (root :modal author))
+    :coref ((s8x1 :same-entity s13x2)))
+
+
+################################################################################
+# meta-info
+# :: snt14
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
+Words: 公务员 娇妻 ， 在 年底 晒 “ 几千 元 海鲜 提货券 ” 、 “ 近 千 元 水果 和 泰康 食品 券 ” 以及 几千 元 “ 年夜饭 半成品 套餐 ” ，
+
+# sentence level graph:
+(s14x / 晒-04
+     :aspect performance
+     :ARG0 (s14x2 / 娇妻
+         :possessor (s14x9 / 公务员))
+     :ARG1 (s14x4 / and
+         :op1 (s14x5 / 套餐
+             :ARG1-of (s14h2 / have-mod-91
+                 :ARG2 (s14x3 / 几)
+                     :op1 (s14m2 / monetary-quantity
+                         :quant 1000)
+                         :unit (s14x10 / 元))
+             :mod (s14x6 / 年夜饭)
+             :mod (s14x11 / 半成品))
+         :op2 (s14x12 / 提货券
+             :ARG1-of (s14h / have-mod-91
+                 :ARG2 (s14x1 / 几)
+                     :op1 (s14m / monetary-quantity
+                         :unit (s14x15 / 元)
+                         :quant 1000))
+             :mod (s14x13 / 海鲜))
+         :op3 (s14x18 / 券
+             :mod (s14x19 / and
+                 :op1 (s14x20 / 水果)
+                 :op2 (s14x21 / 食品
+                     :name (s14x22 / name
+                         :op1 "泰康")))
+             :ARG1-of (s14h1 / have-mod-91))
+                 :ARG2 (s14x7 / 近)
+                     :op4 (s14m1 / monetary-quantity
+                         :quant 1000)
+                         :unit (s14x8 / 元))
+     :temporal (s14x26 / 年底))
+
+# alignment:
+s14x: 6-6
+s14x2: 2-2
+s14x9: 1-1
+s14x4: 0-0
+s14x5: 30-30
+s14h2: 0-0
+s14m2: 0-0
+s14x6: 28-28
+s14x11: 29-29
+s14x12: 11-11
+s14h: 0-0
+s14m: 0-0
+s14x13: 10-10
+s14x18: 22-22
+s14x19: 0-0
+s14x20: 18-18
+s14x21: 21-21
+s14x22: 0-0
+s14h1: 0-0
+s14x7: 15-15
+s14m1: 0-0
+s14x26: 5-5
+s14x3: 8-8
+s14x10: 17-17
+s14x1: 25-25
+s14x15: 9-9
+s14x8: 26-26
+
+# document level annotation:
+(s14s0 / sentence
+    :temporal ((document-creation-time :depends-on s14x26)
+            (s14x26 :contained s14x))
+    :modal ((author :full-affirmative s14x)
+            (root :modal author))
+    :coref ((s12x8 :same-entity s14x2)))
+
+
+################################################################################
+# meta-info
+# :: snt15
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
+Words: 这样 一 组 文字 中 的 关键词 ， 放到 网络 中 的 效果 ， 是 可想而知 的 。
+
+# sentence level graph:
+(s15x / 可想而知-01
+    :aspect state
+    :ARG0 (s15x2 / 效果
+        :mod (s15x3 / 放到-01
+            :aspect performance
+            :ARG1 (s15x4 / 关键词
+                :ARG1-of (s15x5 / include-91
+                    :ARG2 (s15x6 / 文字
+                        :quant 1
+                        :mod (s15x7 / 这样)
+                        :unit (s15x8 / 组))))
+            :ARG2 (s15x9 / 网络))))
+
+# alignment:
+s15x: 16-16
+s15x2: 13-13
+s15x3: 9-9
+s15x4: 7-7
+s15x5: 0-0
+s15x6: 4-4
+s15x7: 1-1
+s15x8: 3-3
+s15x9: 10-10
+
+# document level annotation:
+(s15s0 / sentence
+    :temporal ((document-creation-time :before s15x3)
+            (s15x3 :after s15x))
+    :modal ((author :full-affirmative s15x3)
+            (author :full-affirmative s15x)
+            (root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt16
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
+Words: 因为 就 众人 的 常识 而言 ， 这些 在 现实 中 确实 存在 ， 谁 也 无法 否认 某些 地方 和 某些 机关 与 部门 ， 没有 这样 那样 的 丰厚 待遇 。
+
+# sentence level graph:
+(s16a1 / and
+    :op1 (s16x11 / 无法-01
+        :mod (s16x7 / 也)
+        :ARG0 (s16x6 / 谁)
+        :aspect state
+        :ARG1 (s16x12 / 否认-01
+            :aspect state
+            :ARG1 (s16x13 / 有-01
+                :aspect state
+                :polarity -
+                :ARG0 (s16x14 / and
+                    :op1 (s16x15 / 地方
+                        :mod (s16x16 / 某些))
+                    :op2 (s16x17 / and
+                        :op1 (s16x18 / 机关)
+                        :mod (s16x19 / 某些)
+                        :op2 (s16x20 / 部门)))
+                :ARG1 (s16x21 / 待遇
+                    :mod (s16x22 / 那样)
+                    :ARG0-of (s16x23 / 丰厚-01
+                        :aspect state)
+                    :mod (s16x24 / 这样)))
+    :cause (s16x4 / 常识
+        :possessor (s16x5 / 众人))
+    :op1 (s16x / 存在-01
+        :mod (s16x1 / 确实)
+        :ARG1 (s16t / thing
+            :mod (s16x3 / 这些))
+        :ARG0 (s16x2 / 现实)
+        :aspect state))))
+
+# alignment:
+s16a1: 0-0
+s16x11: 17-17
+s16x7: 16-16
+s16x6: 15-15
+s16x12: 18-18
+s16x13: 27-27
+s16x14: 0-0
+s16x15: 20-20
+s16x17: 0-0
+s16x18: 23-23
+s16x20: 25-25
+s16x21: 32-32
+s16x22: 29-29
+s16x23: 31-31
+s16x24: 28-28
+s16x4: 5-5
+s16x5: 3-3
+s16x: 13-13
+s16x1: 12-12
+s16t: 0-0
+s16x3: 8-8
+s16x2: 10-10
+s16x16: 19-19
+s16x19: 22-22
+
+# document level annotation:
+(s16s0 / sentence
+    :temporal ((document-creation-time :overlap s16x)
+            (s16x :after s16x12)
+            (s16x :overlap s16x13))
+    :modal ((author :full-affirmative s16x)
+            (author :neutral-affirmative s16x12)
+            (author :full-negative s16x13)
+            (root :modal author)
+            (author :full-affirmative s16x11)
+            (author :full-affirmative s16x23)))
+
+
+################################################################################
+# meta-info
+# :: snt17
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35
+Words: 但 这 种 情况 究竟 是 什么样 的 面积 和 规模 ， 是否 真 如 “ 提货姐 ” 所 晒 的 那样 “ 给力 ” 呢 ？ 就 谁 也 说 不 清楚 了 。
+
+# sentence level graph:
+(s17i1 / identity-91
+    :ARG1-of (s17x10 / 清楚-02
+        :aspect state
+        :ARG1-of (s17x13 / 说-01
+            :aspect state)
+        :mod (s17x12 / 也)
+        :ARG0 (s17x11 / 谁)
+        :polarity -)
+    :aspect state
+    :ARG1-of (s17c / contrast-91)
+    :ARG1 (s17x2 / 情况
+        :ARG0-of (s17x5 / 如-01
+            :aspect state
+            :ARG1 (s17t / thing
+                :ARG0-of (s17x9 / 给力-00
+                    :aspect state
+                    :polarity umr-unknown
+                    :mode interrogative)
+                :ARG1-of (s17x7 / 晒-04
+                    :aspect performance)
+                    :ARG0 (s17x8 / 提货姐))
+            :mod (s17x6 / 真)
+            :polarity umr-unknown
+            :mode interrogative)
+        :unit (s17x4 / 种)
+        :mod (s17x3 / 这))
+    :ARG2 (s17a / and
+        :mode interrogative
+        :op1 (s17x1 / 规模)
+        :op2 (s17x / 面积))
+        :polarity umr-unknown)
+
+# alignment:
+s17i1: 0-0
+s17x10: 33-33
+s17x13: 31-31
+s17x12: 30-30
+s17x11: 29-29
+s17c: 0-0
+s17x2: 4-4
+s17x5: 15-15
+s17t: 0-0
+s17x9: 24-24
+s17x7: 20-20
+s17x8: 17-17
+s17x6: 14-14
+s17x4: 3-3
+s17x3: 2-2
+s17a: 0-0
+s17x1: 11-11
+s17x: 9-9
+
+# document level annotation:
+(s17s0 / sentence
+    :temporal ((document-creation-time :overlap s17i1)
+            (s17i1 :overlap s17x5)
+            (document-creation-time :before s17x7)
+            (s17x7 :before s17x9)
+            (s17x5 :after s17x10)
+            (s17x10 :overlap s17x13))
+    :modal ((author :neutral-affirmative s17i1)
+            (author :neutral-affirmative s17x5)
+            (author :full-affirmative s17x7)
+            (author :neutral-affirmative s17x9)
+            (author :full-negative s17x10)
+            (author :full-affirmative s17x13)
+            (root :modal author))
+    :coref ((s16t :same-event s17x2)
+            (s14x2 :same-entity s17x8)))
+
+
+################################################################################
+# meta-info
+# :: snt18
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43
+Words: 因此 ， 被 “ 提货姐 ” 在 微博 中 表扬 “ 给力 ” 、 但 事实上 形象 大 受 伤害 的 “ 市政府 ” 相关 机构 ， 应该 出面 来 调查 清楚 这 件 事情 的 真伪 ， 并 公布 相关 结果 。
+
+# sentence level graph:
+(s18a1 / and
+    :ARG1-of (s18h / have-cause-91)
+    :op1 (s18x1 / 公布-01
+        :aspect state
+        :ARG1 (s18x2 / 结果)
+            :mod (s18x3 / 相关))
+    :op2 (s18x / 出面-01
+        :ARG0 (s18x10 / 机构
+            :mod (s18c / contrast-91
+                :aspect state
+                :ARG2 (s18x15 / 伤害-01
+                    :aspect performance
+                    :manner (s18x18 / 事实上)
+                    :ARG1 (s18x17 / 形象
+                        :possessor s18x10)
+                    :degree (s18x16 / 大)
+                :ARG1 (s18x12 / 表扬-01
+                    :aspect performance
+                    :place (s18x14 / 微博)
+                    :ARG2 (s18x13 / 给力-00
+                        :aspect performance
+                        :ARG0 s18x10)
+                    :ARG1 s18x10)
+                    :ARG0 (s18p / person
+                              :name (s18n1 / name :op1 "提货姐")))
+            :example (s18g / government-organization
+                         :name (s18n / name :op1 "市政府"))
+            :mod (s18x11 / 相关))
+        :ARG1 (s18x4 / 调查-01
+            :aspect state
+            :ARG1 (s18x6 / 真伪
+                :possessor (s18x7 / 事情
+                    :unit (s18x9 / 件))
+                    :mod (s18x8 / 这))
+            :manner (s18x5 / 清楚))
+        :aspect state)))
+
+# alignment:
+s18a1: 0-0
+s18h: 0-0
+s18x1: 40-40
+s18x2: 42-42
+s18x: 29-29
+s18x10: 26-26
+s18c: 0-0
+s18x15: 20-20
+s18x18: 16-16
+s18x17: 17-17
+s18x16: 18-18
+s18x12: 10-10
+s18x14: 8-8
+s18x13: 12-12
+s18p: 0-0
+s18n1: 0-0
+s18g: 23-23
+s18n: 0-0
+s18x4: 31-31
+s18x6: 37-37
+s18x7: 35-35
+s18x9: 34-34
+s18x8: 33-33
+s18x5: 32-32
+s18x3: 41-41
+s18x11: 25-25
+
+# document level annotation:
+(s18s0 / sentence
+    :temporal ((document-creation-time :before s18x12)
+            (s18x12 :before s18x13)
+            (s18x12 :after s18x15)
+            (s18x15 :after s18x)
+            (s18x :after s18x4)
+            (s18x4 :after s18x1))
+    :modal ((author :full-affirmative s18x12)
+            (author :full-affirmative s18p)
+            (s18p :full-affirmative s18x13)
+            (author :full-affirmative s18x15)
+            (author :partial-affirmative s18x)
+            (author :partial-affirmative s18x4)
+            (author :partial-affirmative s18x1)
+            (root :modal author)
+            (author :full-affirmative s18c)
+            (author :full-affirmative s18x13))
+    :coref ((s17x8 :same-entity s18p)
+            (s17x2 :same-event s18x7)))
+
+
+################################################################################
+# meta-info
+# :: snt19
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 因为 这 涉及 该 市 所有 公务 人员 的 形象 ， 对于 这 类 网络 舆情 ， 千万 不 能 当成 无稽之谈 来 对待 ，
+
+# sentence level graph:
+(s19x1 / 当成-01
+    :cause (s19x8 / 涉及-01
+        :aspect state
+        :ARG1 (s19x10 / 形象
+            :possessor (s19x11 / 人员
+                :place (s19x14 / 市
+                    :mod (s19x15 / 该))
+                :quant (s19x13 / 所有))
+                :mod (s19x12 / 公务))
+        :ARG0 (s19t / thing)
+            :mod (s19x9 / 这))
+    :degree (s19x7 / 千万)
+    :polarity -
+    :aspect state
+    :purpose (s19x6 / 对待-01
+        :aspect state
+        :ARG2 s19x5)
+    :ARG2 (s19x5 / 无稽之谈)
+    :ARG1 (s19x / 舆情
+        :unit (s19x4 / 类)
+        :mod (s19x3 / 这))
+        :mod (s19x2 / 网络))
+
+# alignment:
+s19x1: 21-21
+s19x8: 3-3
+s19x10: 10-10
+s19x11: 8-8
+s19x14: 5-5
+s19x15: 4-4
+s19x13: 6-6
+s19x12: 7-7
+s19t: 0-0
+s19x7: 18-18
+s19x6: 24-24
+s19x5: 22-22
+s19x: 16-16
+s19x4: 14-14
+s19x2: 15-15
+s19x9: 13-13
+s19x3: 2-2
+
+# document level annotation:
+(s19s0 / sentence
+    :temporal ((document-creation-time :overlap s19x8)
+            (s19x8 :after s19x1)
+            (s19x1 :after s19x6))
+    :modal ((author :full-affirmative s19x8)
+            (author :neutral-negative s19x1)
+            (author :full-affirmative s19x6)
+            (root :modal author))
+    :coref ((s18x7 :same-event s19t)))
+
+
+################################################################################
+# meta-info
+# :: snt20
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 这 种 教训 ， 其实 在 包括 彭宇 案 在内 的 很多 事件 中 都 有 过 体现 ， 其 恶劣 后果 ， 可想而知 。
+
+# sentence level graph:
+(s20x / and
+    :op1 (s20x2 / 可想而知-01
+             :ARG0 (s20x3 / 后果
+                 :mod (s20x1 / 恶劣
+                 :possessor s20x8))
+             :aspect state)
+    :op2 (s20x4 / 有-03
+        :mod (s20x13 / 都)
+             :mod (s20x7 / 其实)
+             :aspect state
+             :ARG0 (s20x8 / 事件
+                       :ARG0-of (s20x9 / 包括-01
+                                     :aspect state
+                                     :ARG1 (s20x10 / 案
+                                                :topic (s20x11 / person
+                                                           :name (s20x12 / name
+                                                                      :op1 "彭宇"))))
+                       :quant (s20x14 / 很多))
+             :ARG1 (s20x15 / 体现-01
+                        :ARG1 (s20x16 / 教训
+                                   :unit (s20x17 / 种)
+                                   :mod (s20x18 / 这))
+                        :aspect performance)))
+
+# alignment:
+s20x: 0-0
+s20x2: 24-24
+s20x3: 22-22
+s20x1: 21-21
+s20x4: 16-16
+s20x13: 15-15
+s20x7: 5-5
+s20x8: 13-13
+s20x9: 7-7
+s20x10: 9-9
+s20x11: 0-0
+s20x12: 0-0
+s20x14: 12-12
+s20x15: 18-18
+s20x16: 3-3
+s20x17: 2-2
+s20x18: 1-1
+
+# document level annotation:
+(s20s0 / sentence
+    :temporal ((document-creation-time :overlap s20x9)
+            (s20x9 :after s20x4)
+            (s20x4 :after s20x15)
+            (s20x15 :after s20x2))
+    :modal ((author :full-affirmative s20x9)
+            (author :full-affirmative s20x4)
+            (author :full-affirmative s20x15)
+            (author :full-affirmative s20x2)
+            (root :modal author)))
+
+

--- a/chinese/umr_data/chinese_umr-0030.umr
+++ b/chinese/umr_data/chinese_umr-0030.umr
@@ -1,0 +1,684 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+Words: 据 北京 晚报 报道 ， 铁路 客户 服务 中心 12306.cn 网站 最近 故障 频 出 。
+
+# sentence level graph:
+(s1x / 根据-01
+    :ARG1 (s1x2 / 报道-01
+              :ARG0 (s1x3 / newspaper
+                        :name (s1x4 / name
+                                  :op1 "北京"
+                                  :op2 "晚报"))
+              :aspect performance)
+    :ARG0 (s1x5 / 出-04
+              :ARG1 (s1x6 / 故障-01)
+              :aspect activity
+              :mod (s1x7 / 频)
+              :ARG0 (s1x8 / 网站
+                        :name (s1x9 / name
+                                  :op1 "服务"
+                                  :op2 "铁路"
+                                  :op3 "客户"
+                                  :op4 "中心"
+                                  :op5 "12306.cn"))
+              :temporal (s1x10 / 最近)))
+
+# alignment:
+s1x: 1-1
+s1x2: 4-4
+s1x3: 2-3
+s1x4: 0-0
+s1x5: 15-15
+s1x6: 13-13
+s1x7: 14-14
+s1x8: 6-10
+s1x9: 0-0
+s1x10: 12-12
+
+# document level annotation:
+(s1s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s1x2)
+            (author :neutral-affirmative s1x5)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+Words: 1T 的 业内 人士 表示 ， 12306.cn 网站 目前 使用 的 互联网 证号 为 京 1CP 备 字样 。
+
+# sentence level graph:
+(s2x / 表示-01
+    :ARG1 (s2x2 / identity-91
+               :ARG2 (s2x3 / 字样
+                         :name (s2x4 / name
+                                   :op1 "京"
+                                   :op2 "备"
+                                   :op3 "1CP"))
+               :ARG1 (s2x5 / 证号
+                         :ARG1-of (s2x6 / 使用-01
+                                      :temporal (s2x7 / 目前)
+                                      :ARG0 (s2x8 / 网站
+                                          :name (s2n / name
+                                              :op1 "12306.cn"))
+                                      :aspect activity)
+                         :mod (s2x10 / 互联网)))
+    :aspect perfective
+    :ARG0 (s2x11 / 人士
+              :mod (s2x12 / 业内
+                        :mod (s2x13 / "1T"))))
+
+# alignment:
+s2x: 5-5
+s2x2: 0-0
+s2x3: 15-17
+s2x4: 0-0
+s2x5: 13-13
+s2x6: 10-10
+s2x7: 9-9
+s2x8: 8-8
+s2n: 0-0
+s2x10: 12-12
+s2x11: 4-4
+s2x12: 3-3
+s2x13: 1-1
+
+# document level annotation:
+(s2s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s2x)
+            (author :neutral-affirmative s2x6)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43
+Words: 京 1CP 备 的 证号 下 的 网站 应 是 非 经营性 网站 ， 按 法律 规定 不 能 进行 线上 的 商业 经营 ， 但 12306.cn 却 在 线上 售票 ， 有关 人士 建议 12306.cn 尽快 完善 自己 的 互联网 证件 。
+
+# sentence level graph:
+(s3x / and
+    :op1 (s3b / but-91
+	:op1(s3a / and
+	    :op1 (s3x15 / 按-02
+		:ARG1 (s3x24 / 法律))
+	    :op2 (s3x5 / 进行-01
+		:ARG1 (s3x12 / 经营
+                    :mod (s3x14 / 商业))
+                    :mod (s3x13 / 线上))
+		:cause (s3x26 / identity-91
+                          :ARG1 (s3x27 / 网站
+                               :mod (s3x28 / 下
+                                     :op1 (s3x29 / 证号
+                                          :mod (s3x30 / 京1cp备))))
+                          :ARG2 (s3x31 / 网站
+                                :mod (s3x32 / 经营性
+                                     :polarity -)))))
+        :op2 (s3x9 / 售-01
+            :ARG0 (s3u1 / url-entity
+                :value (s3x11 / 12306.cn))
+            :place (s3x10 / 线上)
+            :ARG1 (s3x33 / 票))
+    :op3 (s3x2 / 建议-01
+         :ARG2 (s3u / url-entity
+             :value "12306.cn")
+         :aspect performance
+         :ARG0 (s3x6 / 人士
+             :mod (s3x7 / 有关))
+         :ARG1 (s3x1 / 完善-01
+             :ARG1 (s3x3 / 证件
+                 :possessor s3u
+                 :mod (s3x4 / 互联网))
+             :ARG0 s3u
+             :manner (s3x8 / 尽快))))
+
+# alignment:
+s3x: 0-0
+s3b: 0-0
+s3a: 0-0
+s3x15: 15-15
+s3x24: 16-16
+s3x5: 20-20
+s3x12: 24-24
+s3x14: 23-23
+s3x26: 0-0
+s3x28: 6-6
+s3x29: 5-5
+s3x32: 12-12
+s3x9: 31-31
+s3u1: 0-0
+s3x2: 35-35
+s3u: 0-0
+s3x6: 34-34
+s3x7: 33-33
+s3x1: 38-38
+s3x3: 42-42
+s3x4: 41-41
+s3x8: 37-37
+s3x13: 21-21
+s3x27: 13-13
+s3x30: 3-3
+s3x31: 8-8
+s3x11: 36-36
+s3x10: 30-30
+
+# document level annotation:
+(s3s0 / sentence
+    :modal ((root :modal author)
+            (author :full-negative s3b)
+            (author :partial-affirmative s3x26)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+Words: 作为 铁道部 设置 的 网站 ， 怎么 可能 搞 “ 无证 经营 ” ?
+
+# sentence level graph:
+(s4x / and
+    :op1 (s4x8 / 作为-02
+        :ARG1 (s4x4 / 网站
+            :ARG1-of (s4x10 / 设置-01
+                :aspect performance
+                :ARG0 (s4x11 / 铁道部)))
+        :aspect undirected-activity)
+    :op2 (s4x2 / 可能-01
+        :ARG0 (s4x3 / 搞-01
+            :ARG0 s4x4
+            :aspect state
+            :ARG1 (s4x5 / 经营
+                :manner (s4x6 / 无证)))
+        :aspect state
+        :mode interrogative))
+
+# alignment:
+s4x: 0-0
+s4x8: 1-1
+s4x4: 5-5
+s4x10: 3-3
+s4x11: 2-2
+s4x2: 8-8
+s4x3: 9-9
+s4x5: 12-12
+s4x6: 11-11
+
+# document level annotation:
+(s4s0 / sentence
+    :modal ((root :modal author)
+            (author :full-affirmative s4x8)
+            (author :full-affirmative s4x10)
+            (author :partial-negative s4x2)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38
+Words: 要 知道 ， 这 个 售票 网站 一 开放 ， 必然 要 承受 巨大 的 压力 ， 如果 不 基本 具备 承载 这 个 巨大 压力 的 冲击 ， 想必 铁道部 不 会 轻易 开始 运营 网站 。
+
+# sentence level graph:
+(s5a / and
+	:ARG0 (s5x2 / 知道-01
+		:ARG1 (s5x3 / and
+			:op1 (s5x4 / have-condition-91
+				:ARG2 (s5x25 / 具备-01
+            				:degree (s5x26 / 基本)
+            				:aspect state
+            				:polarity -
+            				:ARG1 (s5x27 / 承载-01
+                				:ARG1 (s5x28 / 冲击-01
+                    					:ARG0 (s5x29 / 压力
+                        					:unit (s5x30 / 个
+									:mod (s5x32 / 这))
+                        					:mod (s5x31 / 巨大-01
+                            					:aspect state)))))
+				:ARG1 (s5x17 / 想必
+                			:ARG0 (s5x18 / 会-02
+						:ARG1 (s5x21 / 铁道部)
+                    				:ARG0 (s5x19 / 开始-01
+							:ARG1 (s5x22 / 运营-03
+								:ARG0 s5x21
+								:ARG1 (s5x23 / 网站))
+                        				:manner (s5x20 / 轻易)
+						:polarity -))))
+			:op2 (s5x16 / have-condition-91
+				:ARG1 (s5x5 / 必然-01
+                    			:ARG0 (s5x6 / 要-03
+                        			:ARG0 (s5x7 / 承受-01
+                            				:ARG0 (s5x8 / 网站
+                                				:unit (s5x9 / 个)
+                                					:mod (s5x10 / 这)
+                                				:mod (s5x11 / 售票))
+                        				:ARG1 (s5x12 / 压力
+                            					:mod(s5x13 / 巨大-01
+                                					:aspect state)))))
+				:ARG2 (s5x14 / 开放-01
+            				:ARG1 s5x8
+            				:aspect state)))))
+
+# alignment:
+s5a: 0-0
+s5x2: 2-2
+s5x3: 0-0
+s5x4: 0-0
+s5x25: 21-21
+s5x26: 20-20
+s5x27: 22-22
+s5x28: 28-28
+s5x17: 30-30
+s5x18: 33-33
+s5x21: 31-31
+s5x19: 35-35
+s5x22: 36-36
+s5x20: 34-34
+s5x16: 0-0
+s5x5: 11-11
+s5x7: 13-13
+s5x11: 6-6
+s5x14: 9-9
+s5x29: 26-26
+s5x30: 24-24
+s5x32: 23-23
+s5x31: 25-25
+s5x23: 37-37
+s5x6: 12-12
+s5x8: 7-7
+s5x9: 5-5
+s5x10: 4-4
+s5x12: 16-16
+s5x13: 14-14
+
+# document level annotation:
+(s5s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s5x4)
+            (s5x4 :neutral-affirmative s5x25)
+            (s5x4 :unspecified s5x17)
+            (author :neutral-affirmative s5x16)
+            (s5x16 :unspecified s5x5)
+            (s5x16 :full-negative s5x14)
+            (author :neutral-affirmative s5x27)
+            (author :neutral-affirmative s5x28)
+            (author :neutral-affirmative s5x31)
+            (author :full-negative s5x19)
+            (author :full-affirmative s5x7)
+            (author :full-affirmative s5x13)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+Words: 为了 分流 售票 ， 铁道部 不 可能 对 售票 网站 马马虎虎 ， 至少 不 会 在 网站 的 合法 身份 上 含糊 吧 ?
+
+# sentence level graph:
+(s6x / and
+    :purpose (s6x1 / 分流-01
+        :ARG1 (s6x16 / 售票-01)
+        :ARG0 (s6x15 / 铁道部))
+    :op1 (s6x4 / 可能-01
+              :ARG0 (s6x2 / 对-06
+                  :manner (s6x6 / 马马虎虎)
+                  :ARG1 (s6x3 / 网站
+                      :mod (s6x5 / 售票))
+                  :ARG0 s6x15)
+              :aspect activity
+              :polarity -)
+    :op2 (s6x9 / 会-02
+             :polarity -
+             :mod (s6x10 / 至少)
+             :aspect state
+             :ARG0 (s6x11 / 含糊-01
+                       :ARG0 (s6x12 / 身份
+                                 :ARG0-of (s6x13 / 合法-01
+                                              :aspect reversible-state)
+                                 :place (s6x14 / 网站))
+                       :aspect state
+                       :mode interrogative)))
+
+# alignment:
+s6x: 0-0
+s6x1: 2-2
+s6x15: 5-5
+s6x4: 7-7
+s6x2: 8-8
+s6x6: 11-11
+s6x9: 15-15
+s6x10: 13-13
+s6x11: 22-22
+s6x12: 20-20
+s6x13: 19-19
+s6x16: 3-3
+s6x3: 10-10
+s6x5: 9-9
+s6x14: 17-17
+
+# document level annotation:
+(s6s0 / sentence
+    :modal ((root :modal author)
+            (author :full-negative s6x4)
+            (author :neutral-negative s6x9)
+            (author :neutral-negative s6x11)
+            (author :neutral-affirmative s6x13)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+Words: 证照 不 全 那 岂 不 是 “ 搬起 石头 砸 自己 的 脚 ” ?
+
+# sentence level graph:
+(s7x / have-condition-91
+    :ARG1 (s7x2 / 全-01
+              :ARG0 (s7x3 / 证照)
+              :aspect state
+              :polarity -)
+    :mode interrogative
+    :ARG2 (s7x4 / identity-91
+               :ARG1 s7x2
+               :ARG2 (s7x6 / 砸-01
+                         :polarity -
+                         :ARG1 (s7x7 / 脚)
+                         :manner (s7x8 / 搬起-01
+                                     :ARG0 (s7x9 / 自己
+                                               :part s7x7)
+                                     :mod (s7x11 / 岂)
+                                     :ARG1 (s7x12 / 石头)
+                                     :aspect state)
+                         :aspect state)))
+
+# alignment:
+s7x: 0-0
+s7x2: 3-3
+s7x3: 1-1
+s7x4: 0-0
+s7x6: 11-11
+s7x7: 14-14
+s7x8: 9-9
+s7x9: 12-12
+s7x11: 5-5
+s7x12: 10-10
+
+# document level annotation:
+(s7s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s7x)
+            (s7x :neutral-negative s7x2)
+            (s7x :unspecified s7x4)
+            (author :neutral-affirmative s7x6)
+            (author :neutral-affirmative s7x8)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34
+Words: 我 宁愿 相信 这 是 1T 业内 人士 的 不实 言论 ， 但 前提 是 铁道部 要 主动 站 出来 澄清 事实 ， 拿出 充分 的 证据 来 有力 还击 此 种 指责 。
+
+# sentence level graph:
+(s8x / contrast-91
+     :ARG1 (s8x2 / 宁愿-01
+                :aspect performance
+                :ARG0 (s8x12 / individual-person
+                           :refer-person 1st
+                           :refer-number singular))
+                :ARG1 (s8x3 / 相信-01
+                           :ARG1 (s8x4 / identity-91
+                                      :ARG1 (s8x5 / thing
+                                                 :mod (s8x6 / 这))
+                                      :ARG2 (s8x7 / 言论
+                                                 :possessor (s8x8 / 人士
+                                                            :mod (s8x9 / 业内
+                                                                        :mod (s8x10 / "1T"))))
+                                                 :mod (s8x11 / 不实-01
+                                                     :ARG0 s8x7
+                                                     :aspect irreversible-state))
+                           :aspect state
+                           :ARG0 s8x12)
+     :ARG2 (s8x14 / and
+               :op1 (s8x15 / identity-91
+                         :ARG1 (s8x16 / 前提)
+                         :ARG2 (s8x17 / 要-03
+                                   :ARG0 (s8x18 / 站-01
+                                              :manner (s8x19 / 出来)
+                                              :aspect state
+                                              :purpose (s8x20 / 澄清-01
+                                                            :ARG0 (s8x21 / 铁道部)
+                                                            :aspect state
+                                                            :ARG1 (s8x22 / 事实))
+                                              :manner (s8x23 / 主动)
+                                              :ARG0 s8x21)
+                                   :aspect state))
+               :op2 (s8x25 / 拿出-01
+                         :purpose (s8x26 / 还击-01
+                                      :aspect state
+                                      :mod (s8x27 / 有力)
+                                      :ARG1 (s8x28 / 指责
+                                                :mod (s8x29 / 此)
+                                                :unit (s8x30 / 种))
+                                      :ARG0 s8x21)
+                         :aspect state
+                         :ARG0 s8x21
+                         :ARG1 (s8x33 / 证据
+                                   :ARG0-of (s8x34 / 充分-01
+                                                :aspect state)))))
+
+# alignment:
+s8x: 0-0
+s8x2: 2-2
+s8x12: 0-0
+s8x3: 3-3
+s8x4: 0-0
+s8x5: 0-0
+s8x6: 4-4
+s8x7: 11-11
+s8x8: 8-8
+s8x9: 7-7
+s8x10: 6-6
+s8x11: 10-10
+s8x14: 0-0
+s8x15: 0-0
+s8x16: 14-14
+s8x17: 17-17
+s8x18: 19-19
+s8x19: 20-20
+s8x20: 21-21
+s8x21: 16-16
+s8x22: 22-22
+s8x23: 18-18
+s8x25: 24-24
+s8x26: 30-30
+s8x27: 29-29
+s8x28: 33-33
+s8x29: 31-31
+s8x30: 32-32
+s8x33: 27-27
+s8x34: 25-25
+
+# document level annotation:
+(s8s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s8x)
+            (author :neutral-affirmative s8x3)
+            (author :neutral-affirmative s8x11)
+            (author :full-affirmative s8x17)
+            (author :neutral-affirmative s8x18)
+            (author :neutral-affirmative s8x20)
+            (author :full-affirmative s8x25)
+            (author :full-affirmative s8x26)
+            (author :neutral-affirmative s8x34)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
+Words: 但 如果 迟迟 不 出来 解释 ， 那 我们 只 能 相信 这 原来 是 真 的 ， 只是 情何以堪 ?
+
+# sentence level graph:
+(s9x / but
+    :op1 (s9x4 / contrast-91
+             :ARG1 (s9x5 / have-condition-91
+                 :aspect activity
+                 :ARG2 (s9x6 / 出来
+                     :polarity -
+                     :purpose (s9x7 / 解释)
+                     :mod (s9x8 / 迟迟))
+                 :ARG1 (s9x10 / 能-01
+                     :ARG0 (s9x11 / 相信-01
+                         :ARG0 (s9x12 / individual-person
+                             :refer-number plural
+                             :refer-person 1st)
+                         :ARG1 (s9x1 / 这
+                             :mod (s9x9 / 真))
+                      :aspect activity
+                      :mod (s9x15 / 只))))
+	      :ARG2 (s9x2 / 情何以堪
+                  :mode interrogative
+                  :mod (s9x3 / 只是))))
+
+# alignment:
+s9x: 0-0
+s9x4: 0-0
+s9x5: 0-0
+s9x6: 5-5
+s9x7: 6-6
+s9x8: 3-3
+s9x10: 11-11
+s9x11: 12-12
+s9x12: 0-0
+s9x1: 13-13
+s9x9: 16-16
+s9x15: 10-10
+s9x2: 20-20
+s9x3: 19-19
+
+# document level annotation:
+(s9s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s9x5)
+            (s9x5 :unspecified s9x6)
+            (s9x5 :unspecified s9x10)
+            (author :partial-affirmative s9x11)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53
+Words: 站 在 铁道部 的 角度 ， 出面 补办 一 个 正规 的 互联网 证件 并 不 难 ， 难 的 是 补偿 不 了 众多 网友 对 政府 部门 公营 机构 的 信任 ， 而 如此 匆匆 上马 草草 运行 ， 又 如何 保证 修补 的 网站 不 再 故障 频 出 ?
+
+# sentence level graph:
+(s10x / and
+    :op1 (s10x2 / have-condition-91
+              :ARG2 (s10x3 / 保证-01
+                  :mode interrogative)
+                  :aspect state
+                  :ARG1 (s10x6 / 出-04
+                       :polarity -
+                       :mod (s10x7 / 再)
+                       :aspect state
+                       :ARG0 (s10x8 / 网站
+                             :ARG1-of (s10x9 / 修补-01
+                                  :aspect reversible-state))
+                       :frequency (s10x10 / 频)
+                       :ARG1 (s10x11 / 故障)))
+              :ARG1 (s10x12 / and
+                         :op1 (s10x13 / 运行
+                             :mod (s10x14 / 草草))
+                         :degree (s10x15 / 如此)
+                         :op2 (s10x16 / 上马-01
+                             :mod (s10x17 / 匆匆)))
+    :op2 (s10x18 / identity-91
+              :ARG2 (s10x19 / 补偿-01
+                        :polarity -
+                        :aspect undirected-endeavor
+                        :ARG1 (s10x20 / 信任-01
+                                   :aspect imperfective
+                                   :ARG0 (s10x21 / 网友
+                                             :quant (s10x22 / 众多))
+                                   :ARG1 (s10x23 / and
+                                              :op1 (s10x24 / 机构
+                                                        :mod (s10x25 / 公营))
+                                              :op2 (s10x26 / 部门
+                                                        :mod (s10x27 / 政府)))))
+              :ARG1 (s10x28 / thing
+                         :ARG0-of (s10x29 / 难-01
+                                       :aspect imperfective)))
+    :op3 (s10x30 / 难-01
+             :aspect imperfective
+             :ARG0 (s10x31 / 出面
+                        :manner (s10x32 / 站-01
+                                     :ARG1 (s10x33 / 角度
+                                                :mod (s10x34 / 铁道部))
+                                     :aspect imperfective)
+                        :purpose (s10x35 / 补办-01
+                                      :ARG1 (s10x36 / 证件
+                                                 :ARG0-of (s10x37 / 正规-01)
+                                                     :aspect inherent-state
+                                                     :ARG0 (s10x38 / 互联网)
+                                                 :unit (s10x39 / 个)
+                                                 :quant 1)
+                                      :aspect activity))
+             :polarity -))
+
+# alignment:
+s10x: 0-0
+s10x2: 0-0
+s10x3: 44-44
+s10x6: 52-52
+s10x7: 49-49
+s10x8: 47-47
+s10x9: 45-45
+s10x10: 51-51
+s10x11: 50-50
+s10x12: 0-0
+s10x13: 40-40
+s10x14: 39-39
+s10x15: 36-36
+s10x16: 38-38
+s10x17: 37-37
+s10x18: 0-0
+s10x19: 22-22
+s10x20: 33-33
+s10x21: 26-26
+s10x22: 25-25
+s10x23: 0-0
+s10x24: 31-31
+s10x25: 30-30
+s10x26: 29-29
+s10x27: 28-28
+s10x28: 0-0
+s10x31: 7-7
+s10x32: 1-1
+s10x33: 5-5
+s10x34: 3-3
+s10x35: 8-8
+s10x36: 14-14
+s10x37: 11-11
+s10x38: 13-13
+s10x39: 10-10
+s10x29: 17-17
+s10x30: 19-19
+
+# document level annotation:
+(s10s0 / sentence
+    :modal ((root :modal author)
+            (author :neutral-affirmative s10x2)
+            (s10x2 :unspecified s10x3)
+            (s10x2 :neutral-negative s10x6)
+            (author :neutral-affirmative s10x9)
+            (author :neutral-negative s10x19)
+            (author :neutral-negative s10x20)
+            (author :neutral-affirmative s10x29)
+            (author :full-negative s10x30)
+            (author :neutral-affirmative s10x32)
+            (author :neutral-affirmative s10x35)
+            (author :full-affirmative s10x37)))
+
+

--- a/chinese/umr_data/chinese_umr-0031.umr
+++ b/chinese/umr_data/chinese_umr-0031.umr
@@ -1,0 +1,790 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
+Words: 自 2025 年 1 月 7 日起 ， 一系列 持续 的 野火 影响 了 美国 加利福尼亚州 洛杉矶 都会区 及 周边 地区
+
+# sentence level graph:
+(s1x / 影响-01
+    :ARG0 (s1x2 / 野火
+        :mod (s1x4 / 一系列)
+        :mod (s1x3 / 持续-01
+            :aspect state))
+    :ARG1 (s1a / and
+        :op1 (s1x1 / 地区
+            :part-of s1l
+            :mod (s1x6 / 周边))
+        :op2 (s1l / local-region
+                 :name (s1n / name :op1 "洛杉矶" :op2 "都会区")
+            :part-of (s1r / region
+                         :name (s1n1 / name :op1 "加利福尼亚州")
+                :part-of (s1c / country
+                             :name (s1n2 / name :op1 "美国")))))
+    :start (s1d / date-entity
+        :year 2025
+        :month 1
+        :day 7)
+    :aspect performance)
+
+# alignment:
+s1x: 13-13
+s1x2: 12-12
+s1x4: 9-9
+s1x3: 10-10
+s1a: 0-0
+s1x1: 21-21
+s1x6: 20-20
+s1l: 17-18
+s1n: 0-0
+s1r: 16-16
+s1n1: 0-0
+s1c: 15-15
+s1n2: 0-0
+s1d: 0-0
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((s1x3 :overlap s1x))
+    :modal ((root :modal author)
+            (author :full-affirmative s1x)
+            (author :full-affirmative s1x3)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48
+Words: 这些 火灾 包括 帕利塞兹 火灾 、 伊顿 火灾 、 赫斯特 火灾 和 日落 火灾 ， 火势 因 极 低 的 湿度 、 长期 干旱 以及 飓风 块别 的 圣塔 安那 风 加剧 ， 某些 地区 的 风速 甚至 超过 每小时 80 英里 （ 130 公里 / 小时 ）
+
+# sentence level graph:
+(s2a1 / and
+    :op1 (s2x9 / 超过-02
+        :ARG0 (s2x17 / 风速)
+        :place (s2x18 / 地区
+            :mod (s2x19 / 某些))
+        :ARG1 (s2o / or
+            :op1 (s2t2 / temporal-expression
+                :quant 130
+                :unit (s2u2 / unit-of-measure
+                    :name (s2n7 / name
+                        :op1 "公里"))
+                :frequency (s2x21 / 每小时))
+            :op2 (s2t / temporal-expression
+                :frequency (s2x20 / 每小时)
+                :unit (s2u / unit-of-measure
+                    :name (s2n6 / name
+                        :op1 "英里")
+                :quant 80)))
+        :mod (s2x22 / 甚至)
+        :aspect state)
+    :op2 (s2x1 / 加剧-01
+        :aspect performance
+        :cause (s2a2 / and
+            :op1 (s2x10 / 湿度
+                :mod (s2x11 / 低
+                    :mod (s2x12 / 极)))
+            :op2 (s2x8 / 干旱
+                :temporal (s2x13 / 长期))
+            :op3 (s2e / event
+                     :name (s2n1 / name :op1 "圣塔" :op2 "安那" :op3 "风")
+                :manner (s2x14 / 飓风-块别)))
+        :ARG1 (s2x3 / 火势))
+    :op3 (s2x / 包括-01
+        :ARG0 (s2x2 / 火灾)
+        :ARG1 (s2a / and
+            :op1 (s2x4 / 火灾
+                :place (s2c2 / city-district
+                    :name (s2n / name
+                        :op1 "帕利塞兹")))
+        :op2 (s2x5 / 火灾
+            :place (s2c3 / city-district
+                :name (s2n2 / name
+                    :op1 "伊顿")))
+        :op3 (s2x6 / 火灾
+            :place (s2c4 / city-district
+                :name (s2n3 / name
+                    :op1 "赫斯特")))
+        :op4 (s2x7 / 火灾
+            :place (s2c5 / city-district
+                :name (s2n4 / name
+                    :op1 "日落"))))
+        :aspect state))
+
+# alignment:
+s2a1: 0-0
+s2x9: 39-39
+s2x17: 37-37
+s2x18: 35-35
+s2x19: 34-34
+s2o: 0-0
+s2t2: 0-0
+s2u2: 45-45
+s2n7: 0-0
+s2x21: 40-40
+s2t: 0-0
+s2x20: 40-40
+s2u: 42-42
+s2n6: 0-0
+s2x22: 38-38
+s2x1: 32-32
+s2a2: 0-0
+s2x10: 21-21
+s2x11: 19-19
+s2x12: 18-18
+s2x8: 24-24
+s2x13: 23-23
+s2e: 29-31
+s2n1: 0-0
+s2x3: 16-16
+s2x: 3-3
+s2a: 0-0
+s2c2: 4-4
+s2n: 0-0
+s2c3: 7-7
+s2n2: 0-0
+s2c4: 10-10
+s2n3: 0-0
+s2c5: 13-13
+s2n4: 0-0
+s2x14: 26-26
+s2x2: 2-2
+s2x4: 5-5
+s2x5: 8-8
+s2x6: 11-11
+s2x7: 14-14
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((s2x9 :before s2x1))
+    :modal ((root :modal author)
+            (author :full-affirmative s2x1))
+    :coref ((s1x2 :same-event s2x2)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
+Words: 截至 1 月 15 日 ， 这些 野火 已 造成 25 人 死亡 ， 超过 1.3 万栋 建筑物 受损 ， 并 迫使 超过 20 万人 撤离
+
+# sentence level graph:
+(s3a / and
+    :temporal (s3x15 / 截至
+        :ARG0 (s3d2 / date-entity
+        :month 1
+        :day 15))
+    :op1 (s3x / 造成-02
+        :ARG0 (s3x3 / 野火
+            :mod (s3x4 / 这些))
+        :ARG1 (s3x6 / 死亡-01
+            :ARG1 (s3x7 / 人
+                :quant 25)
+            :aspect performance)
+        :aspect performance)
+    :op2 (s3x2 / 受损-01
+        :ARG1 (s3x9 / 建筑物
+            :quant 13000
+            :unit (s3x10 / 栋))
+        :aspect performance
+        :mod (s3x11 / 超过))
+    :op3 (s3x5 / 迫使-01
+        :ARG1 (s3x12 / 人
+            :quant 200000
+            :ARG0-of (s3x14 / 撤离-01
+                :aspect performance))
+        :aspect performance))
+
+# alignment:
+s3a: 0-0
+s3x15: 1-1
+s3d2: 0-0
+s3x: 10-10
+s3x3: 8-8
+s3x4: 7-7
+s3x6: 13-13
+s3x7: 12-12
+s3x2: 19-19
+s3x9: 18-18
+s3x10: 17-17
+s3x5: 22-22
+s3x12: 12-12
+s3x14: 26-26
+s3x11: 23-23
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((s3x6 :contained s3x)
+            (s3x2 :contained s3x)
+            (s3x :after s3x5))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x)
+            (author :full-affirmative s3x6)
+            (author :full-affirmative s3x2)
+            (author :full-affirmative s3x5)
+            (author :full-affirmative s3x14))
+    :coref ((s3x3 :same-event s2x2)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10
+Words: 此次 风暴 及其 引发 的 火灾 危险 早 有 预兆
+
+# sentence level graph:
+(s4e1 / exist-91
+    :temporal (s4x6 / 早)
+    :ARG2 (s4x / 预兆-01
+        :aspect state)
+        :ARG1 (s4x1 / 引发-01
+            :aspect performance
+            :ARG1 (s4x3 / 危险)
+                :mod (s4x4 / 火灾))
+            :ARG0 (s4x2 / 风暴)
+                :mod (s4x5 / 此次))
+
+# alignment:
+s4e1: 0-0
+s4x6: 8-8
+s4x: 10-10
+s4x1: 4-4
+s4x3: 7-7
+s4x4: 6-6
+s4x2: 2-2
+s4x5: 1-1
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((s4x1 :before s4x))
+    :modal ((root :modal author)
+            (author :full-affirmative s4x)
+            (author :full-affirmative s4x1)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
+Words: 早在 1 月 2 日 ， 美国 国家 跨 部门 消防 中心 即 警告 南加州 将 出现 “ 高于 正常 水平 的 重大 火灾 潜力 ”
+
+# sentence level graph:
+(s5x / 警告-01
+    :temporal (s5x10 / 早在
+        :calendar (s5d / date-entity
+            :day 2)
+            :month 1)
+    :mod (s5x1 / 即)
+    :ARG0 (s5g / government-organization
+              :name (s5n / name :op1 "国家" :op2 "跨" :op3 "部门" :op4 "消防" :op5 "中心")
+        :place (s5c1 / country
+                   :name (s5n1 / name :op1 "美国")))
+    :ARG1 (s5x2 / 出现-01
+        :mod (s5x3 / 将)
+        :ARG1 (s5x4 / 潜力
+            :mod (s5x5 / 火灾
+                :mod (s5x6 / 重大)))
+        :mod (s5x7 / 高于-01
+            :ARG1 (s5x8 / 水平
+                :mod (s5x9 / 正常))
+            :aspect state)
+        :place (s5c / country-region
+            :name (s5n2 / name
+                :op1 "南加州"))
+        :aspect activity)
+    :aspect performance)
+
+# alignment:
+s5x: 14-14
+s5x10: 1-1
+s5d: 0-0
+s5x1: 13-13
+s5g: 8-12
+s5n: 0-0
+s5c1: 7-7
+s5n1: 0-0
+s5x2: 17-17
+s5x3: 16-16
+s5x4: 25-25
+s5x5: 24-24
+s5x6: 23-23
+s5x7: 19-19
+s5x8: 21-21
+s5x9: 20-20
+s5c: 15-15
+s5n2: 0-0
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((s5x2 :contained s5x))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x)
+            (author :full-affirmative s5x2)
+            (author :full-affirmative s5x7)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+Words: 同日 ， 国家 气象局 在 地方 预报 中 也 提及 可能 发生 强烈 火灾
+
+# sentence level graph:
+(s6x / 提及-01
+    :ARG0 (s6a / agency
+        :name (s6n / name
+            :op1 "国家"
+            :op2 "气象局"))
+    :ARG1 (s6x2 / 发生-01
+        :ARG1 (s6x3 / 火灾
+            :mod (s6x4 / 强烈))
+        :mod (s6x5 / 可能)
+        :aspect state)
+    :temporal (s6x6 / 同日)
+    :mod (s6x7 / 也)
+    :topic (s6x8 / 预报-01
+        :aspect state
+        :ARG0 s6a
+        :mod (s6x9 / 地方))
+    :aspect performance)
+
+# alignment:
+s6x: 10-10
+s6a: 3-4
+s6n: 0-0
+s6x2: 12-12
+s6x3: 14-14
+s6x4: 13-13
+s6x5: 11-11
+s6x6: 1-1
+s6x7: 9-9
+s6x8: 7-7
+s6x9: 6-6
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((document-creation-time :before s6x)
+            (s6x :contained s6x8)
+            (s6x2 :contained s6x))
+    :modal ((root :modal author)
+            (author :full-affirmative s6x)
+            (author :partial-affirmative s6x2)
+            (author :full-affirmative s6x8)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54
+Words: 到 1 月 3 日 ， 风暴 预测 中心 进一步 预测 1 月 8 日 的 火灾 天气 将 达到 “ 严重 风险 ” 级别 ， 并 在 1 月 7 日 — — 首个 关键 火灾 天气 日 — — 将 1 月 8 日 的 风险级别 提升 至 “ 极端 关键 ”
+
+# sentence level graph:
+(s7a / and
+    :op1 (s7x7 / 提升-02
+        :aspect performance
+        :temporal (s7d2 / date-entity
+            :ARG1-of (s7i / identity-91
+                :ARG2 (s7x10 / 天气-日
+                    :mod (s7x13 / 首个)
+                    :mod (s7x12 / 关键))
+                    :mod (s7x11 / 火灾))
+            :month 1
+            :day 7)
+        :ARG2 (s7x9 / 极端-关键)
+        :ARG1 (s7x8 / 风险级别
+            :temporal (s7d1 / date-entity
+                :day 8)
+                :month 1)
+        :ARG0 s7o)
+    :op2 (s7x / 预测-01
+        :aspect performance
+        :ARG1 (s7x1 / 达到-01
+            :aspect state
+            :mod (s7x5 / 将)
+            :ARG0 (s7x3 / 天气
+                :temporal (s7d / date-entity
+                    :day 8)
+                    :month 1)
+                :mod (s7x4 / 火灾))
+            :ARG1 (s7x2 / 级别)
+                :mod (s7x6 / 严重-风险))
+        :ARG0 (s7o / organization
+                  :name (s7n / name :op1 "风暴" :op2 "预测" :op3 "中心")))
+
+# alignment:
+s7a: 0-0
+s7x7: 49-49
+s7d2: 0-0
+s7i: 0-0
+s7x13: 35-35
+s7x8: 48-48
+s7d1: 0-0
+s7x1: 20-20
+s7d: 0-0
+s7x2: 25-25
+s7o: 7-11
+s7n: 0-0
+s7x10: 32-32
+s7x12: 36-36
+s7x11: 37-37
+s7x9: 52-52
+s7x: 11-11
+s7x5: 19-19
+s7x3: 18-18
+s7x4: 17-17
+s7x6: 22-22
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((document-creation-time :before s7x)
+            (s7x1 :contained s7x)
+            (s7x7 :before s7x))
+    :modal ((root :modal author)
+            (author :full-affirmative s7x7)
+            (author :full-affirmative s7x)
+            (author :full-affirmative s7x1)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37
+Words: 针对 洛杉矶 及 文图拉 县 ， 国家 气象局 发布 了 红旗 警告 ， 指出 火灾 风险 极高 ， 并 形容 这 是 一种 “ 特别 危险 的 情况 ” ， 对 生命 及 财产 构成 重大 威胁
+
+# sentence level graph:
+(s8a / and
+    :op1 (s8x5 / 形容-01
+        :ARG0 s8a2
+        :ARG1 (s8x7 / 情况
+            :ARG1-of (s8i / identity-91
+                :ARG2 (s8x10 / 构成-01
+                    :aspect state
+                    :ARG1 (s8x11 / 威胁-01
+                        :aspect state
+                        :mod (s8x14 / 重大))
+                        :ARG1 (s8a1 / and
+                            :op1 (s8x13 / 财产))
+                            :op1 (s8x12 / 生命))
+                    :ARG0 s8x7)
+            :mod (s8x6 / 危险
+                :degree intensifier)))
+    :op2 (s8x / 警告-01
+        :ARG0 (s8a2 / agency
+            :name (s8n / name
+                :op1 "国家"
+                :op2 "气象局"))
+        :ARG1 (s8x2 / 红旗)
+        :place (s8a3 / and
+            :op1 (s8c / city
+                :name (s8n3 / name
+                    :op1 "洛杉矶"))
+            :op2 (s8c2 / county
+                :name (s8n2 / name
+                    :op1 "文图拉"
+                    :op2 "县")))
+        :aspect performance
+        :purpose (s8a4 / and
+            :op1 (s8x3 / 指出-01
+                :ARG0 s8a2
+                :ARG1 (s8x8 / 高-01
+                    :ARG0 (s8x1 / 风险
+                        :mod (s8x9 / 火灾))
+                    :mod (s8x4 / 极)
+                    :aspect state)
+                :aspect state))))
+
+# alignment:
+s8a: 0-0
+s8x5: 20-20
+s8x7: 28-28
+s8i: 0-0
+s8x10: 35-35
+s8x11: 37-37
+s8x14: 36-36
+s8a1: 0-0
+s8x13: 34-34
+s8x12: 32-32
+s8x6: 26-26
+s8x: 12-12
+s8a2: 7-8
+s8n: 0-0
+s8x2: 11-11
+s8a3: 0-0
+s8c: 2-2
+s8n3: 0-0
+s8c2: 4-5
+s8n2: 0-0
+s8a4: 0-0
+s8x3: 14-14
+s8x8: 17-17
+s8x1: 16-16
+s8x9: 15-15
+s8x4: 17-17
+
+# document level annotation:
+(s8s0 / sentence
+    :temporal ((s8x3 :contained s8x)
+            (s8x5 :before s8x)
+            (s8x10 :contained s8x5)
+            (s8x11 :contained s8x5)
+            (s8x8 :contained s8x3))
+    :modal ((root :modal author)
+            (author :full-affirmative s8x5)
+            (author :full-affirmative s8x10)
+            (author :full-affirmative s8x11)
+            (author :full-affirmative s8x)
+            (author :full-affirmative s8x3)
+            (author :full-affirmative s8x8)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+Words: 该 警告 强调 ， 强风 与 低 湿度 的 结合 将 导致 火灾 迅速 蔓延
+
+# sentence level graph:
+(s9x1 / 强调
+    :aspect performance
+    :ARG1 (s9x2 / 结合-02
+        :aspect performance
+        :ARG0-of (s9x6 / 导致-01
+            :aspect state
+            :ARG1 (s9x7 / 蔓延-01
+                :aspect state
+                :manner (s9x9 / 蔓延-迅速))
+                :ARG0 (s9x8 / 火灾))
+        :ARG1 (s9a / and
+            :op1 (s9x4 / 湿度)
+                :mod (s9x5 / 低))
+            :op1 (s9x3 / 强风))
+    :ARG0 (s9x / 警告))
+
+# alignment:
+s9x1: 3-3
+s9x2: 10-10
+s9x6: 12-12
+s9x7: 15-15
+s9x8: 13-13
+s9a: 0-0
+s9x4: 8-8
+s9x5: 7-7
+s9x3: 5-5
+s9x: 2-2
+s9x9: 14-14
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((s9x2 :after s9x6)
+            (s9x6 :after s9x7)
+            (past-reference :contained s9x1))
+    :modal ((root :modal author)
+            (author :full-affirmative s9x1)
+            (author :full-affirmative s9x2)
+            (author :full-affirmative s9x6)
+            (author :full-affirmative s9x7)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
+Words: 自 2024 年 夏末 以来 ， 南加州 逐渐 进入 干燥 状态 ， 因为 风暴 系统 主要 影响 太平洋 西北部 及 北加州 ， 未 对 南加州 带来 有效 降雨
+
+# sentence level graph:
+(s10c1 / consecutive
+    :temporal (s10x11 / 夏末
+        :year 2024)
+    :op1 (s10x1 / 进入-01
+        :aspect performance
+        :mod (s10x10 / 逐渐)
+        :ARG1 (s10x8 / 状态
+            :mod (s10x9 / 干燥))
+        :ARG0 (s10l2 / local-region
+                  :name (s10n3 / name :op1 "南加州")))
+    :cause (s10x / 影响-01
+        :aspect performance
+        :mod (s10x5 / 主要)
+        :ARG1 (s10a / and
+            :op1 (s10l / local-region
+                     :name (s10n1 / name :op1 "北加州"))
+            :op2 (s10w / world-region
+                     :name (s10n / name :op1 "太平洋" :op2 "西北部")))
+        :ARG0 (s10x3 / 系统)
+            :mod (s10x4 / 风暴))
+        :cause-of (s10x2 / 带来-01
+            :polarity -
+            :aspect state
+            :ARG2 (s10x6 / 降雨
+                :mod (s10x7 / 有效))
+            :ARG1 (s10l1 / local-region
+                      :name (s10n2 / name :op1 "南加州")))
+            :ARG0 s10x3)
+
+# alignment:
+s10c1: 0-0
+s10x11: 4-4
+s10x1: 9-9
+s10x10: 8-8
+s10x8: 11-11
+s10x9: 10-10
+s10n3: 0-0
+s10x: 17-17
+s10x5: 16-16
+s10a: 0-0
+s10l: 21-21
+s10n1: 0-0
+s10w: 18-19
+s10n: 0-0
+s10x3: 15-15
+s10x4: 14-14
+s10x2: 26-26
+s10x6: 28-28
+s10x7: 27-27
+s10n2: 0-0
+s10l2: 7-7
+s10l1: 25-25
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((s10x1 :before s10x)
+            (s10x2 :contained s10x))
+    :modal ((root :modal author)
+            (author :full-affirmative s10x1)
+            (author :full-affirmative s10x)
+            (author :full-negative s10x2)))
+
+
+################################################################################
+# meta-info
+# :: snt11
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+Words: 这 一 现象 是 厄尔尼诺 - 南方 涛动 现象 从 圣婴 向 拉尼娜 过渡 的 结果
+
+# sentence level graph:
+(s11i3 / identity-91
+    :ARG1 (s11x / 现象
+        :mod (s11x2 / 这))
+    :ARG2 (s11x3 / 结果
+        :ARG1-of (s11i / identity-91
+            :ARG2 (s11x1 / 过渡-01
+                :ARG2 (s11e2 / event
+                          :name (s11n2 / name :op1 "拉尼娜"))
+                :ARG1 (s11e1 / event
+                          :name (s11n1 / name :op1 "圣婴"))
+                :ARG0 (s11e / event
+                          :name (s11n / name :op1 "厄尔尼诺" :op2 "-" :op3 "南方" :op4 "涛动"))))
+        :ARG2-of s11x1
+    :aspect state))
+
+# alignment:
+s11i3: 0-0
+s11x2: 1-1
+s11x3: 16-16
+s11i: 0-0
+s11x1: 14-14
+s11e2: 13-13
+s11n2: 0-0
+s11e1: 11-11
+s11n1: 0-0
+s11e: 5-8
+s11n: 0-0
+s11x: 3-3
+
+# document level annotation:
+(s11s0 / sentence
+    :temporal ((s11x1 :contained s11i3))
+    :modal ((root :modal author)
+            (author :full-affirmative s11i3)))
+
+
+################################################################################
+# meta-info
+# :: snt12
+Index: 1 2 3 4 5 6 7 8 9 10 11
+Words: 2025 年 1 月 ， 拉尼娜 现象 已 形成 弱势 模式
+
+# sentence level graph:
+(s12x6 / 形成
+    :temporal (s12d / date-entity
+        :year 2025
+        :month 1)
+    :aspect performance
+    :ARG0 (s12e / event
+              :name (s12n / name :op1 "拉尼娜" :op2 "现象"))
+    :ARG1 (s12x1 / 模式)
+        :mod (s12x / 弱势))
+
+# alignment:
+s12x6: 9-9
+s12d: 0-0
+s12e: 6-7
+s12n: 0-0
+s12x1: 11-11
+s12x: 10-10
+
+# document level annotation:
+(s12s0 / sentence
+    :temporal ((past-reference :contained s12x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s12x6)))
+
+
+################################################################################
+# meta-info
+# :: snt13
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
+Words: 到 2024 年 12 月 下旬 ， 洛杉矶 县 大部分 地区 已 陷入 中度 干旱 ， 这种 情况 导致 火灾 风险 在 雨季 中 持续 攀升
+
+# sentence level graph:
+(s13c / consecutive
+    :op1 (s13x / 陷入-01
+        :ARG1 (s13x1 / 干旱
+            :mod (s13x4 / 中度))
+        :ARG0 (s13x2 / 地区
+            :place-of (s13c2 / county
+                :name (s13n / name
+                    :op1 "洛杉矶"
+                    :op2 "县"))
+            :quant (s13x3 / 大部分))
+        :temporal (s13x5 / 下旬
+            :month 12
+            :year 2024)
+        :aspect performance)
+    :op2 (s13x6 / 导致-01
+        :ARG0 s13x
+        :ARG1 (s13x7 / 攀升-01
+            :ARG1 (s13x8 / 风险)
+            :temporal (s13x10 / 中
+                :op1 (s13x11 / 雨季))
+            :aspect process)
+        :aspect state
+        :mod (s13x12 / 持续)))
+
+# alignment:
+s13c: 0-0
+s13x: 13-13
+s13x1: 15-15
+s13x4: 14-14
+s13x2: 11-11
+s13c2: 8-9
+s13n: 0-0
+s13x3: 10-10
+s13x5: 6-6
+s13x6: 19-19
+s13x7: 26-26
+s13x8: 21-21
+s13x10: 24-24
+s13x11: 23-23
+s13x12: 25-25
+
+# document level annotation:
+(s13s0 / sentence
+    :temporal ((past-reference :contained s13x)
+            (s13x :after s13x6)
+            (s13x6 :after s13x7))
+    :modal ((root :modal author)
+            (author :full-affirmative s13x)
+            (author :full-affirmative s13x6)
+            (author :full-affirmative s13x7)))
+
+

--- a/chinese/umr_data/chinese_umr-0032.umr
+++ b/chinese/umr_data/chinese_umr-0032.umr
@@ -1,0 +1,584 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 中国 和 日本 就 福岛 核电站 废水 排海 问题 达成 共识 ， 中国 将 参与 独立 国际 监测 ， 并 逐步 恢复 日本 水产 进口
+
+# sentence level graph:
+(s1a / and
+    :op1 (s1x13 / 恢复-02
+        :aspect process
+        :mod (s1x16 / 逐步)
+        :ARG1 (s1x15 / 进口-01
+            :aspect habitual
+            :ARG2 (s1c4 / country
+                      :name (s1n5 / name :op1 "日本"))
+            :ARG1 (s1x17 / 水产))
+        :ARG0 s1c3)
+    :op2 (s1x8 / 参与-01
+        :aspect state
+        :ARG1 (s1x10 / 监测
+            :mod (s1x12 / 独立)
+            :mod (s1x11 / 国际))
+        :mod (s1x9 / 将)
+        :ARG0 (s1c3 / country
+                  :name (s1n4 / name :op1 "中国")))
+    :op3 (s1x / 达成-01
+        :ARG1 (s1x1 / 共识
+            :topic (s1x5 / 问题
+                :topic (s1x3 / 排-02
+                    :place (s1x4 / 海)
+                    :ARG1 (s1x2 / 废水)
+                    :ARG0 (s1f / facility
+                              :name (s1n1 / name :op1 "核电站")
+                        :mod (s1c1 / country-region
+                                 :name (s1n3 / name :op1 "福岛"))))))
+        :ARG0 (s1a2 / and
+            :op1 (s1c / country
+                :name (s1n / name
+                    :op1 "中国"))
+            :op2 (s1c2 / country
+                :name (s1n2 / name
+                    :op1 "日本")))
+        :aspect performance))
+
+# alignment:
+s1a: 0-0
+s1x13: 22-22
+s1x16: 21-21
+s1x15: 25-25
+s1n5: 0-0
+s1x17: 24-24
+s1x8: 15-15
+s1x10: 18-18
+s1x12: 16-16
+s1x11: 17-17
+s1x9: 14-14
+s1n4: 0-0
+s1x: 10-10
+s1x1: 11-11
+s1x5: 9-9
+s1x3: 8-8
+s1x4: 8-8
+s1x2: 7-7
+s1f: 6-6
+s1n1: 0-0
+s1c1: 5-5
+s1n3: 0-0
+s1a2: 0-0
+s1n: 0-0
+s1n2: 0-0
+s1c4: 23-23
+s1c3: 13-13
+s1c: 1-1
+s1c2: 3-3
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((past-reference :contained s1x)
+            (s1x :after s1x8)
+            (s1x8 :after s1x13))
+    :modal ((root :modal author)
+            (author :full-affirmative s1x)
+            (author :full-affirmative s1x8)
+            (author :full-affirmative s1x13)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72
+Words: 中国 官媒 报道 ， 中国 和 日本 主管 部门 持续 多轮 磋商 福岛 “ 核 污染 水 ” 排海 问题 后 ， 日本 欢迎 在 国际 原子能 机构 框架 下 设立 确保 中国 等 利益 相关 国家 有效 参与 ， 并 确保 独立 采样 和 实验室 分析 的 长期 国际 监测 安排 ， 中国 将 在 实施 监测 措施 后 ， 基于 科学 证据 逐步 恢复 符合 标准 的 日本 水产 进口
+
+# sentence level graph:
+(s2x / 报道-01
+    :aspect performance
+    :ARG0 (s2x2 / 媒
+        :mod (s2c1 / country
+                 :name (s2n1 / name :op1 "中国"))
+        :mod (s2x1 / 官))
+    :ARG1 (s2c2 / consecutive
+        :op1 (s2h2 / have-condition-91
+            :ARG1 (s2x3 / 恢复-02
+                :aspect activity
+                :ARG2 (s2x7 / 符合-01
+                    :aspect state
+                    :ARG1 (s2x23 / 标准))
+                :ARG1 (s2x5 / 进口-01
+                    :ARG1 (s2x6 / 水产)
+                    :ARG2 (s2c6 / country
+                              :name (s2n8 / name :op1 "日本")))
+                :mod (s2x4 / 逐步)
+                :ARG0 (s2c5 / country
+                          :name (s2n7 / name :op1 "中国")))
+            :ARG2 (s2a3 / and
+                :op1 (s2x45 / 基于-01
+                    :aspect state)
+                    :ARG1 (s2x48 / 证据)
+                        :mod (s2x49 / 科学))
+                :op1 (s2x44 / 实施-01
+                    :aspect activity)
+                    :ARG1 (s2x46 / 措施)
+                        :mod (s2x47 / 监测))
+        :op2 (s2h / have-condition-91
+            :ARG2 (s2x10 / 框架
+                :mod (s2i / international-organization
+                         :name (s2n5 / name :op1 "国际" :op2 "原子能" :op3 "机构")))
+            :ARG1 (s2x18 / 欢迎-01
+                :aspect state
+                :ARG2 (s2a2 / and
+                    :op1 (s2x42 / 确保-01
+                        :aspect activity
+                        :ARG1 (s2a / and
+                            :op1 (s2x11 / 安排-01
+                                :ARG1 (s2x13 / 监测-01
+                                    :ARG1 (s2x15 / 分析
+                                        :source (s2x43 / 实验室))
+                                    :ARG0 (s2x12 / 国际))
+                                :mod (s2x14 / 长期)))
+                            :op1 (s2x8 / 采样-01)
+                                :mod (s2x9 / 独立))
+                    :op2 (s2x17 / 设立-01
+                        :aspect activity)
+                        :ARG2 (s2x20 / 确保-01)
+                            :aspect activity)
+                            :ARG1 (s2x16 / 参与-01
+                                :aspect activity
+                                :ARG0 (s2h1 / have-example-91
+                                    :ARG2 (s2c9 / country
+                                              :name (s2n6 / name :op1 "中国")))
+                                    :ARG1 (s2x39 / 国家)
+                                        :mod (s2x40 / 相关)
+                                            :mod (s2x41 / 利益))
+                                :mod (s2x19 / 有效))
+                :ARG0 (s2c8 / country
+                          :name (s2n3 / name :op1 "日本")))
+        :op3 (s2x32 / 持续-01
+            :aspect performance
+            :ARG1 (s2x22 / 多轮)
+            :ARG0 (s2x33 / 磋商-01
+                :aspect performance
+                :ARG1 (s2x21 / 问题
+                    :topic (s2x37 / 排-02)
+                        :ARG1 (s2x38 / 核-污染-水)
+                            :mod (s2c4 / country-region
+                                     :name (s2n / name :op1 "福岛")))
+                        :place (s2x36 / 海))
+                :ARG0 (s2a1 / and
+                    :op1 (s2x34 / 部门
+                        :mod (s2c3 / country
+                                 :name (s2n2 / name :op1 "日本")))
+                        :mod (s2x35 / 主管))
+                    :op1 (s2c / country
+                             :name (s2n4 / name :op1 "中国")))))
+
+# alignment:
+s2x: 3-3
+s2x2: 2-2
+s2n1: 0-0
+s2x1: 2-2
+s2c2: 0-0
+s2h2: 0-0
+s2x3: 66-66
+s2x7: 67-67
+s2x23: 68-68
+s2x5: 72-72
+s2x6: 71-71
+s2n8: 0-0
+s2x4: 65-65
+s2n7: 0-0
+s2a3: 0-0
+s2x45: 62-62
+s2x48: 64-64
+s2x49: 63-63
+s2x44: 57-57
+s2x46: 59-59
+s2h: 0-0
+s2x10: 29-29
+s2n5: 0-0
+s2x18: 24-24
+s2a2: 0-0
+s2a: 0-0
+s2x11: 52-52
+s2x15: 47-47
+s2x43: 46-46
+s2x14: 49-49
+s2x8: 44-44
+s2x9: 43-43
+s2x17: 31-31
+s2x16: 39-39
+s2h1: 0-0
+s2n6: 0-0
+s2x39: 37-37
+s2x40: 36-36
+s2x41: 35-35
+s2x19: 38-38
+s2n3: 0-0
+s2x32: 10-10
+s2x22: 11-11
+s2x33: 12-12
+s2x21: 20-20
+s2c4: 13-13
+s2n: 0-0
+s2x36: 19-19
+s2a1: 0-0
+s2x34: 9-9
+s2n2: 0-0
+s2x35: 8-8
+s2n4: 0-0
+s2c1: 1-1
+s2c6: 70-70
+s2c5: 54-54
+s2x47: 58-58
+s2i: 26-50
+s2x42: 32-32
+s2x13: 51-51
+s2x12: 50-50
+s2x20: 42-42
+s2c9: 5-5
+s2c8: 23-23
+s2x37: 19-19
+s2x38: 16-16
+s2c3: 7-7
+s2c: 33-33
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((document-creation-time :before s2x)
+            (past-reference :contained s2x)
+            (s2x :after s2x32)
+            (s2x32 :overlap s2x33)
+            (s2x33 :after s2x18)
+            (s2x18 :contained s2x17)
+            (s2x17 :overlap s2x20)
+            (s2x20 :after s2x16)
+            (s2x18 :after s2x42)
+            (s2x42 :after s2x44)
+            (s2x44 :after s2x45)
+            (s2x45 :after s2x3))
+    :modal ((root :modal author)
+            (author :full-affirmative s2x)
+            (author :full-affirmative s2x32)
+            (author :full-affirmative s2x33)
+            (author :full-affirmative s2x18)
+            (author :full-affirmative s2x42)
+            (author :full-affirmative s2x17)
+            (author :full-affirmative s2x20)
+            (author :full-affirmative s2x16)
+            (author :neutral-affirmative s2x44)
+            (author :full-affirmative s2x45)
+            (author :full-affirmative s2x3)
+            (author :full-affirmative s2x7)
+            (author :neutral-affirmative s2h2)
+            (s2h2 :full-affirmative s2x3)
+            (s2h2 :unspecified s2a3)
+            (s2h2 :unspecified s2x46)
+            (author :neutral-affirmative s2h)
+            (s2h :unspecified s2x10)
+            (s2h :full-affirmative s2x18))
+    :coref ((s1x5 :same-entity s2x21)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
+Words: 日本 首相 岸田 文雄 表示 ， 国际 原子能 机构 将 扩展 对 “ 处理 水 ” 排海 的 监测 计划 ， 而 目前 他 不知道 中国 具体 何时 会 恢复 进口 日本 水产
+
+# sentence level graph:
+(s3x / 表示-01
+    :ARG0 (s3i2 / individual-person
+        :name (s3n2 / name
+            :op1 "岸田"
+            :op2 "文雄")
+        :ARG1-of (s3h / have-org-role-91
+            :ARG3 (s3x1 / 首相)
+            :ARG2 (s3c1 / country
+                      :name (s3n1 / name :op1 "日本"))))
+    :ARG1 (s3a / and
+        :op1 (s3x11 / 知道-01
+            :ARG1 (s3x14 / 恢复-02
+                :polarity umr-unknown
+                :ARG1 (s3x17 / 进口-01
+                    :ARG2 (s3c3 / country
+                              :name (s3n4 / name :op1 "日本"))
+                    :ARG0 s3c
+                    :ARG1 (s3x18 / 水产))
+                :ARG0 (s3c / country
+                          :name (s3n / name :op1 "中国")))
+            :aspect state
+            :temporal (s3x12 / 目前)
+            :polarity -
+            :ARG0 s3i2)
+        :op2 (s3x3 / 扩展-01
+            :aspect state
+            :mod (s3x6 / 将)
+            :ARG0 (s3i4 / institution
+                :name (s3n3 / name
+                    :op1 "国际"
+                    :op2 "原子能"
+                    :op3 "机构"))
+            :ARG1 (s3x5 / 计划
+                :mod (s3x9 / 监测-01
+                    :ARG1 (s3x15 / 排海
+                        :aspect habitual
+                        :ARG1 (s3x16 / 水
+                            :mod (s3x10 / 处理)))))))
+    :aspect performance)
+
+# alignment:
+s3x: 5-5
+s3i2: 3-4
+s3n2: 0-0
+s3h: 0-0
+s3x1: 2-2
+s3n1: 0-0
+s3a: 0-0
+s3x11: 25-25
+s3x14: 30-30
+s3x17: 31-31
+s3n4: 0-0
+s3x18: 33-33
+s3c: 26-26
+s3n: 0-0
+s3x12: 23-23
+s3x3: 11-11
+s3x6: 10-10
+s3i4: 7-9
+s3n3: 0-0
+s3x5: 20-20
+s3x9: 19-19
+s3x15: 17-17
+s3x16: 15-15
+s3x10: 14-14
+s3c1: 1-1
+s3c3: 32-32
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((document-creation-time :before s3x)
+            (past-reference :contained s3x)
+            (s3x :after s3x3)
+            (s3x :overlap s3x11))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x)
+            (author :full-affirmative s3x3)
+            (s3i2 :full-negative s3x11)
+            (author :full-affirmative s3i2)
+            (author :full-negative s3x11)
+            (author :full-affirmative s3x15))
+    :coref ((s2i :same-entity s3i4)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
+Words: 福岛 第一 核电厂 受 2011 年 东日本 大地震 及 引发 的 海啸 损毁 ， 导致 冷却 系统 停止 运作 ， 东京 电力公司 注入 海水 直接 冷却
+
+# sentence level graph:
+(s4c / consecutive
+    :op1 (s4x4 / 注入-01
+        :aspect performance
+        :ARG1 (s4x14 / 海水
+            :ARG0-of (s4x9 / 冷却-01
+                :aspect performance)
+                :manner (s4x12 / 直接))
+        :ARG0 (s4c2 / company
+            :name (s4n2 / name :op1 "电力公司"))
+            :place (s4c4 / country-region
+                :name (s4n5 / name :op1 "东京")))
+    :op2 (s4x / 损毁-01
+        :ARG1 (s4f / facility
+                :name (s4n / name
+                    :op1 "核电厂")
+            :place (s4c3 / country-region
+                :name (s4n3 / name
+                    :op1 "福岛"))
+            :mod (s4x13 / 第一))
+        :ARG0 (s4a / and
+            :op1 (s4x1 / 海啸
+                :ARG1-of (s4x2 / 引发-01
+                    :aspect performance
+                    :ARG0 s4e))
+            :op2 (s4e / earthquake
+                :name (s4n1 / name
+                    :op1 "大地震")
+                :temporal (s4d1 / date-entity)
+                    :year 2011)
+                :place (s4c1 / country-region
+                    :name (s4n4 / name :op1 "东日本")))
+        :aspect performance)
+    :op3 (s4x5 / 停止-01
+        :ARG0 (s4x6 / 系统
+            :mod (s4x7 / 冷却))
+        :ARG1 (s4x8 / 运作-01
+            :ARG0 s4x6
+            :aspect habitual)
+        :aspect state))
+
+# alignment:
+s4c: 0-0
+s4x4: 23-23
+s4x14: 24-24
+s4x12: 25-25
+s4c2: 22-22
+s4n2: 0-0
+s4c4: 21-21
+s4n5: 0-0
+s4x: 13-13
+s4f: 1-3
+s4n: 0-0
+s4c3: 0-0
+s4n3: 0-0
+s4x13: 2-2
+s4a: 0-0
+s4x1: 12-12
+s4x2: 10-10
+s4e: 8-8
+s4n1: 0-0
+s4d1: 0-0
+s4c1: 7-7
+s4n4: 0-0
+s4x5: 18-18
+s4x6: 17-17
+s4x8: 19-19
+s4x9: 26-26
+s4x7: 16-16
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((past-reference :contained s4x)
+            (s4x :before s4x2)
+            (s4x :after s4x5)
+            (s4x5 :overlap s4x8)
+            (s4x8 :after s4x4)
+            (s4x4 :after s4x9))
+    :modal ((root :modal author)
+            (author :full-affirmative s4x)
+            (author :full-affirmative s4x2)
+            (author :full-affirmative s4x5)
+            (author :full-negative s4x8)
+            (author :full-affirmative s4x4)
+            (author :full-affirmative s4x9)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
+Words: 使用 后 的 核废水 经 12 年 已 储存 30万吨 ，于 去年 开始 分批 排放 ，预计需时 40 年
+
+# sentence level graph:
+(s5c / consecutive
+    :op1 (s5x18 / 预计-01
+        :aspect state
+        :ARG1 (s5x19 / 需-01
+            :ARG0 s5x7
+            :aspect state)
+            :ARG1 (s5t1 / temporal-quantity
+                :unit (s5x20 / 年))
+                :quant 40)
+    :op2 (s5x5 / 开始-01
+        :aspect state
+        :temporal (s5x8 / 年
+            :mod (s5x9 / 去))
+        :ARG1 (s5x7 / 排放-01
+            :aspect habitual
+            :ARG1 s5x2)
+            :mod (s5x17 / 分批))
+    :op3 (s5x / 储存-01
+        :ARG2 (s5x2 / 核废水
+            :unit (s5x3 / 吨)
+            :quant 300000
+            :temporal (s5x1 / 后
+                :op1 (s5x11 / 使用-01)
+                    :ARG1 s5x2)
+                    :aspect performance)
+        :mod (s5x4 / 已)
+        :duration (s5t / temporal-quantity
+            :quant 12
+            :unit (s5x6 / 年))
+        :aspect performance))
+
+# alignment:
+s5c: 0-0
+s5x18: 16-16
+s5x19: 16-16
+s5t1: 0-0
+s5x5: 13-13
+s5x9: 12-12
+s5x7: 15-15
+s5x17: 14-14
+s5x: 9-9
+s5x2: 4-4
+s5x3: 10-10
+s5x1: 2-2
+s5x11: 1-1
+s5x4: 8-8
+s5t: 0-0
+s5x20: 7-7
+s5x8: 18-18
+s5x6: 7-7
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((document-creation-time :before s5x)
+            (past-reference :contained s5x11)
+            (s5x11 :after s5x)
+            (s5x :after s5x5)
+            (s5x5 :overlap s5x7)
+            (s5x7 :after s5x18)
+            (s5x18 :overlap s5x19))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x11)
+            (author :full-affirmative s5x)
+            (author :full-affirmative s5x5)
+            (author :full-affirmative s5x7)
+            (author :full-affirmative s5x18)
+            (author :full-affirmative s5x19)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13
+Words: 日本 称呼 核废水 为 “ 处理水 ” ， 中国 称为 “ 核污染水 ”
+
+# sentence level graph:
+(s6a / and
+    :op1 (s6x1 / 称为-01
+        :aspect state
+        :ARG2 (s6x4 / 核污染水)
+        :ARG1 s6x2
+        :ARG0 (s6c1 / country
+                  :name (s6n1 / name :op1 "中国")))
+    :op2 (s6x / 称呼-01
+        :ARG0 (s6c / country
+            :name (s6n / name
+                :op1 "日本"))
+        :ARG1 (s6x2 / 核废水)
+        :ARG2 (s6x3 / 处理水)
+        :aspect state))
+
+# alignment:
+s6a: 0-0
+s6x1: 10-10
+s6x4: 12-12
+s6c1: 9-9
+s6n1: 0-0
+s6x: 2-2
+s6c: 1-1
+s6n: 0-0
+s6x2: 3-3
+s6x3: 6-6
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((past-reference :contained s6x1)
+            (s6x1 :overlap s6x))
+    :modal ((root :modal author)
+            (author :full-affirmative s6x)
+            (author :full-affirmative s6x1)))
+
+

--- a/chinese/umr_data/chinese_umr-0033.umr
+++ b/chinese/umr_data/chinese_umr-0033.umr
@@ -1,0 +1,876 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
+Words: 黎巴嫩 全国 大量 传呼机 及 对讲机 连续 两日 爆炸 ， 造成 至少 37 死 ， 近 3 , 000 人 受伤
+
+# sentence level graph:
+(s1x / 爆炸-01
+    :ARG1 (s1a2 / and
+        :op1 (s1x3 / 传呼机)
+        :op2 (s1x17 / 对讲机)
+        :quant (s1x4 / 大量)
+        :place (s1c / country
+            :name (s1n / name
+                :op1 "黎巴嫩")
+            :mod (s1x18 / 全国)))
+    :aspect performance
+    :mod (s1x8 / 连续
+        :op1 (s1t / temporal-quantity
+            :unit (s1x9 / 日)
+            :quant 2))
+    :cause-of (s1x12 / 造成-01
+        :ARG1 (s1a / and
+            :op1 (s1x7 / 死-01
+                :ARG0 (s1x11 / 人
+                    :quant 37)
+                :aspect performance
+                :mod (s1x10 / 至少))
+            :op2 (s1x2 / 受伤-01
+                :ARG0 (s1x6 / 人
+                    :quant 3000)
+                :aspect performance
+                :mod (s1x5 / 近)))))
+
+# alignment:
+s1x: 9-9
+s1a2: 0-0
+s1x3: 4-4
+s1x17: 6-6
+s1x4: 3-3
+s1c: 1-1
+s1n: 0-0
+s1x18: 2-2
+s1x8: 7-7
+s1t: 0-0
+s1x9: 8-8
+s1x12: 11-11
+s1a: 0-0
+s1x7: 14-14
+s1x11: 20-20
+s1x10: 12-12
+s1x2: 21-21
+s1x6: 20-20
+s1x5: 16-16
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((s1x :after s1x12)
+        (s1x12 :overlap s1x7))
+    :modal ((root :modal author)
+            (author :full-affirmative s1x)
+            (author :full-affirmative s1x12)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10
+Words: 不少 国民 担心 手中 电话 实为 炸弹 ， 纷纷 弃置
+
+# sentence level graph:
+(s2x / 弃置-01
+    :ARG0 (s2x6 / 国民
+        :quant (s2x7 / 不少))
+    :ARG1 s2x4
+    :mod (s2x2 / 纷纷)
+    :cause (s2x3 / 担心-01
+        :ARG0 s2x6
+        :ARG1 (s2i2 / identity-91
+            :ARG1 (s2x4 / 电话
+                :mod (s2x5 / 手中))
+            :ARG2 (s2x8 / 炸弹)
+            :aspect state)
+        :aspect state)
+    :aspect performance)
+
+# alignment:
+s2x: 10-10
+s2x6: 2-2
+s2x7: 1-1
+s2x2: 9-9
+s2x3: 3-3
+s2i2: 0-0
+s2x4: 5-5
+s2x5: 4-4
+s2x8: 7-7
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((s1x :after s2x)
+            (s2x3 :after s2x)
+            (s2x3 :overlap s2i2))
+    :modal ((root :modal author)
+            (author :full-affirmative s2x)
+            (author :full-affirmative s2x3)
+            (author :full-affirmative s2i2)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+Words: 袭击 针对 亲 伊朗 武装组织 真主党 ， 矛头 直指 与 之 多次 交火 的 以色列
+
+# sentence level graph:
+(s3a / and
+    :op1 (s3x / 针对-01
+        :ARG0 (s3x2 / 袭击
+            :aspect performance)
+        :ARG1 (s3o / organization
+            :name (s3n / name
+                :op1 "真主党")
+            :ARG1-of (s3i2 / identity-91
+                :ARG2 (s3x3 / 组织
+                    :mod (s3x4 / 武装)
+                    :mod (s3x5 / 亲
+                        :mod (s3c2 / country
+                            :name (s3n3 / name
+                                :op1 "伊朗"))))))
+        :aspect performance)
+    :op2 (s3x7 / 指-01
+        :ARG0 (s3x8 / 矛头)
+        :ARG1 (s3c / country
+            :name (s3n2 / name
+                :op1 "以色列")
+            :ARG0-of (s3x6 / 交火-01
+                :ARG1 (s3a2 / and
+                    :op1 s3o
+                    :op2 s3c)
+                :frequency (s3x12 / 多次)
+                :aspect performance))
+        :aspect state))
+
+# alignment:
+s3a: 0-0
+s3x: 2-2
+s3x2: 1-1
+s3o: 6-6
+s3n: 0-0
+s3i2: 0-0
+s3x3: 5-5
+s3x4: 5-5
+s3x5: 3-3
+s3c2: 4-4
+s3n3: 0-0
+s3x7: 9-9
+s3x8: 8-8
+s3c: 15-15
+s3n2: 0-0
+s3x6: 13-13
+s3a2: 0-0
+s3x12: 12-12
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((s3x2 :overlap s3x)
+            (s3x :overlap s3x7)
+            (s3x2 :before s3x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x)
+            (author :full-affirmative s3x2)
+            (author :full-affirmative s3x7)
+            (author :full-affirmative s3x6)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
+Words: 真主 党 领袖 纳斯鲁拉 （ Hassan Nasrallah ） 怒斥 ， 袭击 规模 空前绝后 ， 已经 超越 所有 红线 ， 不顾 一切 法律 及 道德 底线 ， 如同 宣战 及 犯下 战争 罪 行
+
+# sentence level graph:
+(s4x / 怒斥-01
+    :ARG0 (s4i4 / identity-91
+        :ARG1 (s4i6 / individual-person
+            :name (s4n / name
+                :op1 "纳斯鲁拉"))
+        :ARG2 (s4i7 / individual-person
+            :name (s4n5 / name
+                :op1 "Hassan"
+                :op2 "Nasrallah"))
+        :ARG3 (s4x20 / 领袖
+            :ARG3-of (s4h2 / have-org-role-91
+                :ARG2 (s4p / political-organization
+                    :name (s4n6 / name
+                        :op1 "真主"
+                        :op2 "党")))))
+    :ARG1 (s4a / and
+        :op1 (s4x5 / 规模
+            :ARG1-of (s4x21 / 袭击-01
+                :aspect performance)
+            :mod (s4x22 / 空前绝后))
+        :op2 (s4x2 / 超越-01
+            :ARG1 (s4x18 / 红线
+                :quant (s4x19 / 所有))
+            :aspect performance)
+        :op3 (s4x6 / 顾-01
+            :ARG1 (s4a2 / and
+                :op1 (s4x12 / 法律)
+                :op2 (s4x13 / 底线
+                    :mod (s4x14 / 道德))
+                :quant (s4x3 / 一切))
+            :aspect performance
+            :polarity -)
+        :op4 (s4x4 / 如同-01
+            :ARG1 (s4a4 / and
+                :op1 (s4x7 / 宣战-01
+                    :aspect performance)
+                :op2 (s4x8 / 犯下-01
+                    :ARG1 (s4x9 / 罪行
+                        :manner (s4x10 / 战争))
+                    :aspect performance))
+            :aspect state))
+    :aspect performance)
+
+# alignment:
+s4x: 9-9
+s4i4: 0-0
+s4i6: 4-4
+s4n: 0-0
+s4i7: 6-7
+s4n5: 0-0
+s4x20: 3-3
+s4h2: 0-0
+s4p: 1-2
+s4n6: 0-0
+s4a: 0-0
+s4x5: 12-12
+s4x21: 11-11
+s4x22: 13-13
+s4x2: 16-16
+s4x18: 18-18
+s4x19: 17-17
+s4x6: 20-20
+s4a2: 0-0
+s4x12: 22-22
+s4x13: 25-25
+s4x14: 24-24
+s4x3: 21-21
+s4x4: 27-27
+s4a4: 0-0
+s4x7: 28-28
+s4x8: 30-30
+s4x10: 31-31
+s4x9: 32-32
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((s4x21 :after s4x)
+            (s4x2 :overlap s4x21)
+            (s4x6 :overlap s4x21)
+            (s4x4 :overlap s4x6)
+            (s4x7 :overlap s4x4)
+            (s4x8 :overlap s4x4))
+    :modal ((root :modal author)
+            (author :full-affirmative s4x)
+            (author :full-affirmative s4i4)
+            (s4i4 :full-affirmative s4x21)
+            (s4i4 :full-affirmative s4x2)
+            (s4i4 :full-negative s4x6)
+            (s4i4 :full-affirmative s4x4)
+            (s4i4 :full-affirmative s4x7)
+            (s4i4 :full-affirmative s4x8))
+    :coref ((s3o :same-entity s4p)
+            (s3x2 :same-event s4x21)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+Words: 国内 广播 纳斯鲁拉 演讲 的 同时 ， 以色列 也 派出 战机 ， 飞越 黎巴嫩 首都 贝鲁特 并 空袭 黎巴嫩 南部
+
+# sentence level graph:
+(s5a / and
+    :op1 (s5x / 派出-01
+        :ARG0 (s5c / country
+            :name (s5n / name
+                :op1 "以色列"))
+        :ARG1 (s5x2 / 战机
+            :mod (s5x3 / 也))
+        :aspect performance
+        :temporal (s5x16 / 同时
+            :op1 (s5x4 / 广播-01
+                :ARG0 (s5x5 / 国内)
+                :ARG1 (s5x6 / 演讲-01
+                    :ARG0 (s5i4 / individual-person
+                        :name (s5n5 / name
+                            :op1 "纳斯鲁拉"))
+                    :aspect performance)
+                :aspect performance)))
+    :op2 (s5x15 / 飞越-01
+        :ARG0 s5x2
+        :ARG1 (s5c2 / city
+            :name (s5n2 / name
+                :op1 "贝鲁特")
+            :place (s5c3 / country
+                :name (s5n3 / name
+                    :op1 "黎巴嫩"))
+            :ARG1-of (s5i2 / identity-91
+                :ARG2 (s5x10 / 首都)))
+        :aspect performance)
+    :op3 (s5x8 / 空袭-01
+        :ARG0 s5x2
+        :ARG1 (s5x9 / 南部
+            :part (s5c4 / country
+                :name (s5n4 / name
+                    :op1 "黎巴嫩")))
+        :aspect performance))
+
+# alignment:
+s5a: 0-0
+s5x: 10-10
+s5c: 8-8
+s5n: 0-0
+s5x2: 11-11
+s5x3: 9-9
+s5x16: 6-6
+s5x4: 2-2
+s5x5: 1-1
+s5x6: 4-4
+s5i4: 3-3
+s5n5: 0-0
+s5x15: 13-13
+s5c2: 16-16
+s5n2: 0-0
+s5n3: 0-0
+s5i2: 0-0
+s5x10: 15-15
+s5x8: 18-18
+s5x9: 20-20
+s5n4: 0-0
+s5c3: 14-14
+s5c4: 19-19
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((s5x :overlap s5x4)
+            (s5x15 :before s5x)
+            (s5x4 :overlap s5x6)
+            (s5x8 :before s5x15))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x)
+            (author :full-affirmative s5x4)
+            (author :full-affirmative s5x6)
+            (author :full-affirmative s5x15)
+            (author :full-affirmative s5x8))
+    :coref ((s4i6 :same-entity s5i4)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+Words: 以色列 政府 没有 直接 评论 是否 发动 连环爆炸 ， 但 国防 部长 事后 提到 加沙 战争 “ 展开 新 一 阶段 ” ， 又 扬言 会 继续 打击 真主 党
+
+# sentence level graph:
+(s6b / but-91
+    :ARG1 (s6x2 / 评论-02
+        :ARG0 (s6x4 / 政府
+            :mod (s6c2 / country
+                :name (s6n2 / name
+                    :op1 "以色列")))
+        :ARG1 (s6u / umr-choice
+            :op1 (s6x6 / 发动-01
+                :ARG1 (s6x11 / 爆炸-01
+                    :manner (s6x18 / 连环))))
+        :manner (s6x3 / 直接
+            :polarity -)
+        :aspect performance)
+    :ARG2 (s6a / and
+        :op1 (s6x5 / 提到-01
+            :ARG1 (s6i2 / identity-91
+                :ARG2 (s6x7 / 阶段
+                    :mod (s6x8 / 新)
+                    :mod (s6x9 / 一)
+                    :part-of (s6x10 / 展开-01
+                        :ARG1 (s6w / war
+                            :name (s6n3 / name
+                                :op1 "加沙"
+                                :op2 "战争"))
+                        :aspect habitual)))
+            :aspect state
+            :temporal (s6x12 / 事后))
+        :op2 (s6x / 扬言-01
+            :ARG0 (s6x13 / 部长
+                :mod (s6x14 / 国防)
+                :ARG1-of (s6h / have-org-role-91
+                    :ARG2 (s6x15 / 政府
+                        :mod (s6c / country
+                            :name (s6n / name
+                                :op1 "以色列")))))
+            :ARG1 (s6x16 / 继续-01
+                :ARG1 (s6x17 / 打击-01
+                    :ARG0 s6x4
+                    :ARG1 (s6o / organization
+                        :name (s6n4 / name
+                            :op1 "真主"
+                            :op2 "党"))
+                    :aspect state)
+                :aspect habitual)
+            :aspect state)))
+
+# alignment:
+s6b: 0-0
+s6x2: 5-5
+s6x4: 2-2
+s6c2: 1-1
+s6n2: 0-0
+s6u: 0-0
+s6x6: 7-7
+s6x11: 8-8
+s6x18: 8-8
+s6x3: 4-4
+s6a: 0-0
+s6x5: 14-14
+s6i2: 0-0
+s6x7: 21-21
+s6x8: 19-19
+s6x9: 20-20
+s6x10: 18-18
+s6w: 15-16
+s6n3: 0-0
+s6x12: 13-13
+s6x: 25-25
+s6x13: 12-12
+s6x14: 11-11
+s6h: 0-0
+s6x15: 2-2
+s6c: 1-1
+s6n: 0-0
+s6x16: 27-27
+s6x17: 28-28
+s6o: 29-30
+s6n4: 0-0
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((s6x5 :before s6x2)
+            (s6x5 :before s6x10)
+            (s6x :before s6x5)
+            (s6x16 :before s6x17)
+            (s6x11 :before s6x6)
+            (s6x2 :before s6x11))
+    :modal ((root :modal author)
+            (author :full-negative s6x2)
+            (author :full-negative s6x4)
+            (author :full-affirmative s6x10)
+            (author :full-affirmative s6x)
+            (author :full-affirmative s6x13)
+            (s6x13 :full-affirmative s6x16)
+            (s6x13 :full-affirmative s6x17)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12
+Words: 多个 外电 消息 指 ， 爆炸 由 以色列 情报 组织 Mossad 策动
+
+# sentence level graph:
+(s7x / 指-02
+    :ARG0 (s7x2 / 消息
+        :source (s7x6 / 外电)
+        :quant (s7x7 / 多个))
+    :ARG1 (s7x3 / 策动-01
+        :ARG1 (s7x5 / 爆炸)
+        :actor (s7o / organization
+            :name (s7n / name
+                :op1 "Mossad")
+            :ARG1-of (s7i2 / identity-91
+                :ARG2 (s7x4 / 组织
+                    :mod (s7x8 / 情报)
+                    :place (s7c / country
+                        :name (s7n2 / name
+                            :op1 "以色列")))))
+        :aspect performance)
+    :aspect state)
+
+# alignment:
+s7x: 4-4
+s7x2: 3-3
+s7x6: 2-2
+s7x7: 1-1
+s7x3: 12-12
+s7x5: 6-6
+s7o: 11-11
+s7n: 0-0
+s7i2: 0-0
+s7x4: 10-10
+s7x8: 9-9
+s7c: 8-8
+s7n2: 0-0
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((s7x :before s7x3))
+    :modal ((root :modal author)
+            (author :full-affirmative s7x)
+            (author :full-affirmative s7x2)
+            (s7x2 :full-affirmative s7x3))
+    :coref ((s6x11 :same-event s7x5)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+Words: 《 纽约时报 》 报道 ， 以方 渗透 供应链 后 ， 在 通讯 设备 安装 炸药
+
+# sentence level graph:
+(s8x / 报道-01
+    :ARG0 (s8n / newspaper
+        :name (s8n2 / name
+            :op1 "纽约时报"))
+    :ARG1 (s8x2 / 安装-01
+        :ARG0 s8c
+        :ARG1 (s8x3 / 炸药)
+        :ARG2 (s8x4 / 设备
+            :mod (s8x5 / 通讯))
+        :temporal (s8x6 / 后
+            :op1 (s8x7 / 渗透-01
+                :ARG0 (s8c / country
+                    :name (s8n3 / name
+                        :op1 "以方"))
+                :ARG1 (s8x8 / 供应链)
+                :aspect performance))
+        :aspect performance)
+    :aspect performance)
+
+# alignment:
+s8x: 4-4
+s8n: 2-2
+s8n2: 0-0
+s8x2: 14-14
+s8x3: 15-15
+s8x4: 13-13
+s8x5: 12-12
+s8x6: 9-9
+s8x7: 7-7
+s8c: 6-6
+s8n3: 0-0
+s8x8: 8-8
+
+# document level annotation:
+(s8s0 / sentence
+    :temporal ((s8x :before s8x2)
+            (s8x2 :before s8x7))
+    :modal ((root :modal author)
+            (author :full-affirmative s8x)
+            (author :full-affirmative s8n)
+            (s8n :full-affirmative s8x2)
+            (s8n :full-affirmative s8x7))
+    :coref ((s7o :same-entity s8c)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 被指 是 制造商 的 台湾 公司 金 阿波罗 ， 坚决 否认 生产 涉事 设备 ， 另 指 匈牙利 合作 伙伴 获准 使用 金 阿波罗 商标
+
+# sentence level graph:
+(s9a / and
+    :op1 (s9x / 否认-01
+        :ARG0 (s9c3 / company
+            :name (s9n3 / name
+                :op1 "金"
+                :op2 "阿波罗")
+            :ARG1-of (s9x5 / 指-01
+                :ARG2 (s9x6 / 制造商
+                    :ARG1-of (s9i2 / identity-91
+                        :ARG2 s9c3))
+                :aspect state)
+            :place (s9c / country
+                :name (s9n / name
+                    :op1 "台湾")))
+        :ARG1 (s9x2 / 生产-01
+            :ARG0 s9c3
+            :ARG1 (s9x3 / 设备
+                :mod (s9x4 / 涉事))
+            :aspect performance)
+        :aspect performance
+        :manner (s9x19 / 坚决))
+    :op2 (s9x7 / 指-01
+        :ARG0 s9c3
+        :ARG1 (s9x9 / 伙伴
+            :ARG0-of (s9x10 / 获准-01
+                :ARG1 (s9x11 / 使用-01
+                    :ARG1 (s9x12 / 商标
+                        :possessor-of s9c3)
+                    :aspect state)
+                :aspect performance)
+            :mod (s9x13 / 合作)
+            :place (s9c2 / country
+                :name (s9n2 / name
+                    :op1 "匈牙利")))
+        :mod (s9x8 / 另)
+        :aspect performance))
+
+# alignment:
+s9a: 0-0
+s9x: 11-11
+s9n3: 0-0
+s9x5: 17-17
+s9x6: 3-3
+s9i2: 0-0
+s9c: 5-5
+s9n: 0-0
+s9x2: 12-12
+s9x3: 14-14
+s9x4: 13-13
+s9x19: 10-10
+s9x7: 17-17
+s9x9: 20-20
+s9x10: 21-21
+s9x11: 22-22
+s9x12: 25-25
+s9x13: 19-19
+s9c2: 18-18
+s9n2: 0-0
+s9x8: 16-16
+s9c3: 7-24
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((s9x10 :before s9x2)
+            (s9x11 :before s9x10)
+            (s9x :before s9x5)
+            (s9x :before s9x2)
+            (s9x7 :before s9x))
+    :modal ((root :modal author)
+            (author :full-affirmative s9x)
+            (author :full-affirmative s9x5)
+            (author :full-affirmative s9x2)
+            (author :full-affirmative s9x7)
+            (author :full-affirmative s9x10)
+            (author :full-affirmative s9x11)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11
+Words: 匈牙利 政府 随即 撇清 关系 ， 否认 该 公司 设有 厂房
+
+# sentence level graph:
+(s10a / and
+    :op1 (s10x / 撇清-00
+        :ARG0 (s10g / government
+            :place (s10c / country
+                :name (s10n / name
+                    :op1 "匈牙利")))
+        :ARG1 (s10x2 / 关系)
+        :temporal (s10x3 / 随即)
+        :aspect performance)
+    :op2 (s10x4 / 否认-01
+        :ARG0 (s10x9 / 公司
+            :mod (s10x10 / 该))
+        :ARG1 (s10x5 / 设有-01
+            :ARG0 s10x9
+            :ARG1 (s10x8 / 厂房)
+            :aspect state)
+        :aspect performance))
+
+# alignment:
+s10a: 0-0
+s10x: 4-4
+s10g: 0-0
+s10c: 1-1
+s10n: 0-0
+s10x2: 5-5
+s10x3: 3-3
+s10x4: 7-7
+s10x9: 9-9
+s10x10: 8-8
+s10x5: 10-10
+s10x8: 11-11
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((s10x4 :before s10x5)
+            (s10x4 :contained s10x))
+    :modal ((root :modal author)
+            (author :full-affirmative s10x)
+            (author :full-affirmative s10x4)
+            (author :full-affirmative s10x5))
+    :coref ((s9c3 :same-entity s10x9)))
+
+
+################################################################################
+# meta-info
+# :: snt11
+Index: 1 2 3 4 5 6
+Words: 台湾 检控 官 已 展开 调查
+
+# sentence level graph:
+(s11x / 调查-01
+    :ARG0 (s11x2 / 检控-官
+        :mod (s11c / country
+            :name (s11n / name
+                :op1 "台湾")))
+    :aspect process)
+
+# alignment:
+s11x: 6-6
+s11c: 1-1
+s11n: 0-0
+s11x2: 3-3
+
+# document level annotation:
+(s11s0 / sentence
+    :temporal ((present-reference :contained s11x))
+    :modal ((root :modal author)
+            (author :full-affirmative s11x)))
+
+
+################################################################################
+# meta-info
+# :: snt12
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+Words: 另外 ， 以色列 警方 拘捕 一名 商人 ， 指被 伊朗 招揽 成为 刺客 ， 讨论 过 行刺 总理 内塔尼亚胡
+
+# sentence level graph:
+(s12c / consecutive
+    :op1 (s12x / 拘捕-01
+        :ARG0 (s12x3 / 警方
+            :place (s12c2 / country
+                :name (s12n / name
+                    :op1 "以色列")))
+        :ARG1 (s12x4 / 商人
+            :quant 1
+            :unit (s12x5 / 名))
+        :mod (s12x2 / 另外)
+        :aspect performance)
+    :op2 (s12x6 / 指-02
+        :ARG0 s12x3
+        :ARG1 (s12a / and
+            :op1 (s12x7 / 招揽-01
+                :ARG0 (s12c3 / country
+                    :name (s12n2 / name
+                        :op1 "伊朗"))
+                :ARG1 (s12x8 / 刺客
+                    :ARG1-of (s12i3 / identity-91
+                        :ARG2 s12x4))
+                :aspect performance)
+            :op2 (s12x9 / 讨论-01
+                :ARG0 (s12a2 / and
+                    :op1 s12c3
+                    :op2 s12x4)
+                :ARG1 (s12x10 / 行刺-01
+                    :ARG0 s12x4
+                    :ARG1 (s12i2 / individual-person
+                        :name (s12n3 / name
+                            :op1 "内塔尼亚胡")
+                        :ARG1-of (s12i4 / identity-91
+                            :ARG2 (s12x11 / 总理)))
+                    :aspect process)
+                :aspect performance))
+        :aspect state))
+
+# alignment:
+s12c: 0-0
+s12x: 5-5
+s12x3: 4-4
+s12c2: 3-3
+s12n: 0-0
+s12x4: 7-7
+s12x5: 6-6
+s12x2: 1-1
+s12x6: 9-9
+s12a: 0-0
+s12x7: 11-11
+s12c3: 10-10
+s12n2: 0-0
+s12x8: 13-13
+s12i3: 0-0
+s12x9: 15-15
+s12a2: 0-0
+s12x10: 17-17
+s12i2: 19-19
+s12n3: 0-0
+s12i4: 0-0
+s12x11: 18-18
+
+# document level annotation:
+(s12s0 / sentence
+    :temporal ((s12x9 :before s12x7)
+            (s12x :before s12x9)
+            (s12x6 :before s12x))
+    :modal ((root :modal author)
+            (author :full-affirmative s12x)
+            (author :full-affirmative s12x6)
+            (author :full-affirmative s12x7)
+            (author :full-affirmative s12x9)
+            (author :full-affirmative s12x10)))
+
+
+################################################################################
+# meta-info
+# :: snt13
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+Words: 至于 联合国 大会 较早 前 就 通过 决议 ， 要求 以色列 一年 内 停止 非法 占领 约旦 河 西岸
+
+# sentence level graph:
+(s13x / 要求-01
+    :ARG0 (s13i2 / international-organization
+        :name (s13n / name
+            :op1 "联合国"
+            :op2 "大会"))
+    :ARG1 (s13x2 / 停止-01
+        :ARG0 (s13c / country
+            :name (s13n2 / name
+                :op1 "以色列"))
+        :ARG1 (s13x3 / 占领-01
+            :ARG1 (s13x8 / 西岸
+                :part-of (s13r / river
+                    :name (s13n3 / name
+                        :op1 "约旦"
+                        :op2 "河")))
+            :aspect process
+            :mod (s13x9 / 非法))
+        :duration (s13t / temporal-quantity
+            :quant 1
+            :unit (s13x10 / 年))
+        :aspect process)
+    :aspect performance
+    :temporal (s13x6 / 前
+        :op1 (s13x5 / 通过-01
+            :ARG0 (s13s / s13s2)
+            :ARG1 (s13x7 / 决议)
+            :aspect performance)
+        :mod (s13x4 / 较早)))
+
+# alignment:
+s13x: 10-10
+s13i2: 2-3
+s13n: 0-0
+s13x2: 14-14
+s13c: 11-11
+s13n2: 0-0
+s13x3: 16-16
+s13x8: 19-19
+s13r: 17-18
+s13n3: 0-0
+s13x9: 15-15
+s13t: 0-0
+s13x10: 12-12
+s13x6: 5-5
+s13x5: 7-7
+s13s: 0-0
+s13x7: 8-8
+s13x4: 4-4
+
+# document level annotation:
+(s13s0 / sentence
+    :temporal ((s13x :before s13x5)
+            (s13x :overlap s13x2)
+            (s13x :overlap s13x3))
+    :modal ((root :modal author)
+            (author :full-affirmative s13x)
+            (author :full-affirmative s13x2)
+            (author :full-affirmative s13x3)
+            (author :full-affirmative s13x5)))
+
+

--- a/chinese/umr_data/chinese_umr-0034.umr
+++ b/chinese/umr_data/chinese_umr-0034.umr
@@ -1,0 +1,705 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11
+Words: 残奥 闭幕 ， 巴黎 在 狂欢 中 不说 再见 说 你好
+
+# sentence level graph:
+(s1a / and
+    :op1 (s1a1 / and
+        :op1 (s1x / 说-01
+            :aspect performance
+            :ARG1 (s1x2 / 你好))
+        :ARG0 (s1c1 / country-region
+                  :name (s1n2 / name :op1 "巴黎"))
+        :manner (s1x4 / 狂欢
+            :aspect performance)
+        :op2 (s1x1 / 说-01
+            :aspect performance
+            :ARG1 (s1x5 / 再见))
+            :polarity -)
+    :op2 (s1x3 / 闭幕-01
+        :ARG0 (s1s / sports-organization
+                  :name (s1n1 / name :op1 "残奥"))
+        :aspect performance))
+
+# alignment:
+s1a: 0-0
+s1a1: 0-0
+s1x: 10-10
+s1x2: 11-11
+s1c1: 4-4
+s1n2: 0-0
+s1x4: 6-6
+s1x1: 10-10
+s1x5: 9-9
+s1x3: 2-2
+s1s: 1-1
+s1n1: 0-0
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((document-creation-time :before s1x3)
+            (s1x3 :after s1x1)
+            (s1x1 :after s1x))
+    :modal ((root :modal author)
+            (author :full-affirmative s1x3)
+            (author :full-negative s1x1)
+            (author :full-affirmative s1x)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61
+Words: 闭幕礼 在 法兰西 体育场 举行 ， 巴黎 奥组委 主席 埃斯坦盖 致辞 时 说 ， 残 奥 闭幕 意味着 整个 巴黎 2024 年 奥运 及 残奥 的 结束 ， 但 奥运 的 讯息 仍然 相随 ： “ 让 我们 继续 尝试 ， 让 我们 继续 跌倒 ， 让 我们 继续 爬起 ， 让 我们 继续 行动 ， 让 我们 继续 相信 ”
+
+# sentence level graph:
+(s2a1 / and
+    :op1 (s2x2 / 说-01
+        :aspect performance
+        :ARG1 (s2c / contrast-91
+            :ARG2 (s2x6 / 相随-01
+                :aspect state
+                :ARG0 (s2x15 / 讯息
+                    :topic (s2a2 / and
+                        :op1 (s2x23 / 相信-01)
+                        :op2 (s2x22 / 行动-01)
+                        :op3 (s2x21 / 爬起)
+                        :op4 (s2x20 / 跌倒-01)
+                        :mod (s2x19 / 继续)
+                        :ARG0 (s2x18 / 我们)
+                        :op5 (s2x17 / 尝试-01))
+                    :mod (s2x16 / 奥运))
+                :mod (s2x14 / 仍然))
+            :ARG1 (s2x5 / 意味着-01
+                :aspect state
+                :ARG1 (s2x10 / 结束-01
+                    :ARG1 (s2a / and
+                        :mod (s2x13 / 整个)
+                        :place (s2c1 / country-region
+                                   :name (s2n3 / name :op1 "巴黎"))
+                        :temporal (s2d / date-entity
+                            :year 2024)
+                        :op1 (s2x12 / 残奥)
+                        :op2 (s2x11 / 奥运))
+                    :ARG0 s2x7)
+                :ARG0 (s2x7 / 闭幕-01
+                    :aspect performance)
+                    :ARG0 (s2x8 / 奥)
+                        :mod (s2x9 / 残)))
+        :temporal (s2x4 / 致辞-01
+            :aspect performance
+            :ARG0 s2p)
+        :ARG0 (s2p / person
+                  :name (s2n / name :op1 "埃斯坦盖"))
+            :ARG1-of (s2h / have-org-role-92
+                :ARG3 (s2x3 / 主席))
+                :ARG2 (s2s / sports-organization
+                          :name (s2n2 / name :op1 "巴黎" :op2 "奥组委")))
+    :op2 (s2x / 举行-01
+        :aspect performance
+        :place (s2s1 / sports-facility
+                   :name (s2n1 / name :op1 "法兰西" :op2 "体育场")))
+        :ARG1 (s2x1 / 闭幕礼))
+
+# alignment:
+s2a1: 0-0
+s2x2: 13-13
+s2c: 0-0
+s2x6: 34-34
+s2x15: 32-32
+s2a2: 0-0
+s2x23: 60-60
+s2x22: 55-55
+s2x21: 50-50
+s2x20: 45-45
+s2x17: 40-40
+s2x14: 33-33
+s2x5: 18-18
+s2x10: 27-27
+s2a: 0-0
+s2x13: 19-19
+s2n3: 0-0
+s2d: 0-0
+s2x12: 25-25
+s2x7: 17-17
+s2x8: 16-16
+s2x9: 15-15
+s2x4: 11-11
+s2p: 0-0
+s2n: 0-0
+s2h: 0-0
+s2x3: 9-9
+s2n2: 0-0
+s2x: 5-5
+s2s1: 3-4
+s2n1: 0-0
+s2x1: 1-1
+s2x19: 44-44
+s2x18: 43-43
+s2x16: 30-30
+s2c1: 20-20
+s2x11: 23-23
+s2s: 7-20
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((document-creation-time :before s2x)
+            (s2x :contained s2x4)
+            (s2x4 :overlap s2x5)
+            (s2x5 :overlap s2x6)
+            (s2x6 :after s2x17)
+            (s2x17 :after s2x20)
+            (s2x20 :after s2x21)
+            (s2x21 :after s2x22)
+            (s2x22 :after s2x23))
+    :modal ((root :modal author)
+            (author :full-affirmative s2x)
+            (author :full-affirmative s2x4)
+            (author :full-affirmative s2p)
+            (s2p :full-affirmative s2x5)
+            (s2p :full-affirmative s2x6)
+            (s2p :full-affirmative s2x17)
+            (s2p :full-affirmative s2x20)
+            (s2p :full-affirmative s2x21)
+            (s2p :full-affirmative s2x22)
+            (s2p :full-affirmative s2x23)
+            (author :full-affirmative s2x2)
+            (s2p :full-affirmative s2c)
+            (s2p :full-affirmative s2x7))
+    :coref ((s1x3 :same-event s2x1)
+            (s2x1 :same-event s2x7)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8
+Words: 最 重要 的 ， 让 我们 继续 勇敢
+
+# sentence level graph:
+(s3x / 继续-01
+    :ARG0 (s3p1 / person
+        :refer-number plural
+        :refer-person 1st)
+    :ARG1 (s3x2 / 勇敢-01
+        :ARG0 s3p1
+        :aspect state)
+    :mod (s3x3 / 重要-01
+        :mod (s3x4 / 最)
+        :aspect state)
+    :aspect state)
+
+# alignment:
+s3x: 7-7
+s3p1: 0-0
+s3x2: 8-8
+s3x3: 2-2
+s3x4: 1-1
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((document-creation-time :overlap s3x)
+            (s3x :overlap s3x2))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x)
+            (author :full-affirmative s3x2)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9
+Words: 不如 说 这 只 是 一种 文化 不同 。
+
+# sentence level graph:
+(s4x1 / 说
+    :aspect state
+    :ARG1 (s4x2 / 是-01
+        :aspect state
+        :ARG1 (s4x5 / 不同-01
+            :ARG0 (s4x6 / 文化
+                :quant 1)
+                :unit (s4x7 / 种))
+        :ARG0 (s4x4 / 这)
+        :mod (s4x3 / 只))
+    :mod (s4x / 不如))
+
+# alignment:
+s4x1: 2-2
+s4x2: 5-5
+s4x5: 8-8
+s4x6: 7-7
+s4x7: 6-6
+s4x4: 3-3
+s4x3: 4-4
+s4x: 1-1
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((document-creation-time :overlap s4x1)
+            (s4x1 :overlap s4x2))
+    :modal ((root :modal author)
+            (author :full-affirmative s4x1)
+            (author :partial-affirmative s4x2)
+            (author :neutral-affirmative s4x1)
+            (author :full-affirmative s4x2)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34
+Words: 和 巴黎 奥运 开幕 时 一样 ， 残奥 闭幕 礼 同样 在 雨中 举行 ， 下届 残奥 举办 城市 洛杉矶 市长 巴斯 接过 国际 残奥 委员会 会旗 ， 洛杉矶 呈献 六分钟 的 交接 表演
+
+# sentence level graph:
+(s5c1 / consecutive
+    :op1 (s5x15 / 呈献-01
+        :aspect performance
+        :ARG1 (s5x16 / 表演
+            :duration (s5t / temporal-quantity
+                :unit (s5x18 / 分钟)
+                :quant 6)
+            :mod (s5x17 / 交接))
+        :ARG0 (s5c3 / country-region
+                  :name (s5n4 / name :op1 "洛杉矶")))
+    :op2 (s5x9 / 接过-01
+        :aspect performance
+        :ARG1 (s5x11 / 会旗
+            :possessor (s5i / international-organization
+                           :name (s5n3 / name :op1 "残奥" :op2 "国际" :op3 "委员会")))
+        :ARG0 (s5p / person
+                  :name (s5n1 / name :op1 "巴斯"))
+            :ARG1-of (s5h / have-org-role-92
+                :ARG3 (s5x10 / 市长))
+                :ARG2 (s5c2 / country-region
+                          :name (s5n2 / name :op1 "洛杉矶"))
+                    :ARG0 (s5x12 / 举办-01)
+                        :ARG1 (s5x13 / 残奥)
+                            :mod (s5x14 / 下届))
+    :op3 (s5x / 举行-01
+        :aspect performance
+        :temporal (s5x5 / 雨中
+            :aspect process)
+        :mod (s5x4 / 同样))
+        :ARG1 (s5x1 / 礼
+            :ARG0-of (s5x6 / 一样-02)
+                :ARG1 (s5x7 / 奥运
+                    :temporal (s5x8 / 开幕-01
+                        :aspect performance))
+                    :mod (s5c / country-region
+                             :name (s5n / name :op1 "巴黎")))
+            :mod (s5x2 / 闭幕)
+                :mod (s5x3 / 残奥))
+
+# alignment:
+s5c1: 0-0
+s5x15: 30-30
+s5x16: 34-34
+s5t: 0-0
+s5x18: 31-31
+s5x17: 33-33
+s5n4: 0-0
+s5x9: 23-23
+s5x11: 27-27
+s5n3: 0-0
+s5p: 0-0
+s5n1: 0-0
+s5h: 0-0
+s5x10: 21-21
+s5n2: 0-0
+s5x12: 18-18
+s5x14: 16-16
+s5x: 14-14
+s5x5: 13-13
+s5x4: 11-11
+s5x1: 10-10
+s5x6: 6-6
+s5x7: 3-3
+s5x8: 4-4
+s5c: 2-2
+s5n: 0-0
+s5x2: 9-9
+s5c3: 29-29
+s5i: 8-26
+s5c2: 20-20
+s5x13: 17-17
+s5x3: 8-8
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((document-creation-time :before s5x8)
+            (s5x8 :after s5x2)
+            (s5x2 :overlap s5x)
+            (s5x :after s5x9)
+            (s5x9 :after s5x15)
+            (s5x15 :after s5x12))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x8)
+            (author :full-affirmative s5x2)
+            (author :full-affirmative s5x)
+            (author :full-affirmative s5x12)
+            (author :full-affirmative s5x9)
+            (author :full-affirmative s5x15)
+            (author :full-affirmative s5x7))
+    :coref ((s2x7 :same-event s5x2)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+Words: 六名 法国 残奥 运动员 在 体育场 内 吹熄 火种 灯 后 ， 在 杜乐丽 花园 的 主 火炬 随即 熄灭
+
+# sentence level graph:
+(s6x / 熄灭-01
+    :ARG1 (s6x2 / 火炬
+        :mod (s6x3 / 主)
+        :place (s6p / park
+            :name (s6n / name
+                :op1 "杜乐丽"
+                :op2 "花园")))
+    :manner (s6x4 / 随即)
+    :temporal (s6x5 / 后
+        :op1 (s6x1 / 吹熄
+            :aspect performance
+            :place (s6s / sports-facility
+                       :name (s6n2 / name :op1 "体育场"))
+            :ARG1 (s6x9 / 灯)
+                :mod (s6x10 / 火种))
+            :ARG0 (s6x6 / 运动员
+                :mod (s6x8 / 残奥)
+                :place (s6c / country
+                           :name (s6n1 / name :op1 "法国"))
+                :unit (s6x7 / 名))
+                :quant 6)
+    :aspect performance)
+
+# alignment:
+s6x: 20-20
+s6x2: 18-18
+s6x3: 17-17
+s6p: 14-15
+s6n: 0-0
+s6x4: 19-19
+s6x5: 11-11
+s6x1: 8-8
+s6s: 6-6
+s6n2: 0-0
+s6x9: 10-10
+s6x10: 9-9
+s6x6: 4-4
+s6x8: 3-3
+s6c: 2-2
+s6n1: 0-0
+s6x7: 1-1
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((document-creation-time :before s6x1)
+            (s6x1 :after s6x))
+    :modal ((root :modal author)
+            (author :full-affirmative s6x1)
+            (author :full-affirmative s6x)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+Words: 闭幕 礼 进入 一小时 的 派对 表演 ， 24 名 电子 音乐 制作人 参与 ， 由 76 岁 的 殿堂级 艺术家 Jean-Michel André 打头阵 ， Kavinsky 、 Kungs 等 DJ 悉数登场
+
+# sentence level graph:
+(s7a / and
+    :op1 (s7x / 进入-01
+        :aspect performance
+        :ARG0 (s7x2 / 礼
+            :mod (s7x1 / 闭幕))
+        :ARG1 (s7x4 / 表演-01
+            :mod (s7x3 / 派对)
+            :duration (s7t / temporal-quantity
+                :quant 1
+                :unit (s7x6 / 小时))))
+    :op2 (s7x7 / 参与-01
+        :ARG1 s7x4
+        :ARG0 (s7x8 / 制作人
+            :mod (s7x9 / 音乐
+                :mod (s7x10 / 电子))
+            :quant 24
+            :unit (s7x11 / 名))
+        :aspect performance)
+    :op3 (s7x12 / 打头阵-01
+        :ARG0 (s7x13 / 艺术家
+            :age (s7t1 / temporal-quantity
+                :unit (s7x5 / 岁)
+                :quant 76)
+            :mod (s7x14 / 殿堂级)
+            :ARG1-of (s7i2 / identity-91
+                :ARG2 (s7p / person
+                          :name (s7n1 / name :op1 "Jean-Michel" :op2 "André"))))
+        :aspect performance)
+    :op4 (s7x16 / 登场-01
+        :manner (s7x15 / 悉数)
+        :ARG0 (s7x17 / dj
+            :example (s7a1 / and
+                :op1 (s7p2 / person
+                         :name (s7n2 / name :op1 "Kungs")))
+                :op1 (s7p1 / person
+                         :name (s7n / name :op1 "Kavinsky")))
+        :aspect performance))
+
+# alignment:
+s7a: 0-0
+s7x: 3-3
+s7x2: 2-2
+s7x1: 1-1
+s7x4: 7-7
+s7x3: 6-6
+s7t: 0-0
+s7x6: 4-4
+s7x7: 14-14
+s7x8: 13-13
+s7x9: 12-12
+s7x10: 11-11
+s7x11: 10-10
+s7x12: 24-24
+s7x13: 21-21
+s7t1: 0-0
+s7x5: 18-18
+s7x14: 20-20
+s7i2: 0-0
+s7p: 22-23
+s7n1: 0-0
+s7x16: 31-31
+s7x15: 31-31
+s7x17: 0-0
+s7a1: 0-0
+s7p2: 0-0
+s7n2: 0-0
+s7p1: 0-0
+s7n: 0-0
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((document-creation-time :before s7x)
+            (s7x :after s7x7)
+            (s7x7 :after s7x12)
+            (s7x12 :after s7x16))
+    :modal ((root :modal author)
+            (author :full-affirmative s7x)
+            (author :full-affirmative s7x7)
+            (author :full-affirmative s7x12)
+            (author :full-affirmative s7x16))
+    :coref ((s5x2 :same-event s7x1)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36
+Words: 最后 上台 表演 的 Martin Solveig 以 《 Hello 》 和 Daft Punk 的 金曲 《 One More Time 》 收尾 ， 13 日 的 巴黎 残奥 和 长达 一个 半月 的 巴黎 盛会 正式 落幕
+
+# sentence level graph:
+(s8a / and
+    :op1 (s8x3 / 收尾-01
+        :aspect performance
+        :ARG1 s8a3
+        :ARG0 (s8p / person
+                  :name (s8n1 / name :op1 "Martin" :op2 "Solveig")
+            :ARG0-of (s8x1 / 表演-01
+                :aspect performance
+                :temporal (s8x / 最后))
+                :manner (s8x2 / 上台-01
+                    :aspect performance))
+        :ARG2 (s8a2 / and
+            :op1 (s8m1 / music
+                     :name (s8n2 / name :op1 "One" :op2 "More" :op3 "Time")
+                :ARG1-of (s8i / identity-91)
+                    :ARG2 (s8x4 / 金曲)
+                        :possessor (s8p1 / performing-group
+                                       :name (s8n3 / name :op1 "Daft" :op2 "Punk")))
+            :op2 (s8m / music
+                     :name (s8n / name :op1 "Hello"))))
+    :op2 (s8x6 / 落幕-01
+        :aspect performance
+        :ARG0 (s8a3 / and
+            :op1 (s8x7 / 残奥
+                :duration (s8t / temporal-quantity
+                    :unit (s8x5 / 日)
+                    :quant 13)
+                :place (s8c1 / country-region
+                           :name (s8n4 / name :op1 "巴黎")))
+            :op2 (s8x8 / 盛会
+                :duration (s8t1 / temporal-quantity
+                    :unit (s8x11 / 月)
+                    :quant (s8x9 / 一个半))
+                :place (s8c / country-region
+                           :name (s8n5 / name :op1 "巴黎"))))
+        :manner (s8x10 / 正式)))
+
+# alignment:
+s8a: 0-0
+s8x3: 21-21
+s8p: 5-6
+s8n1: 0-0
+s8x1: 3-3
+s8x: 1-1
+s8x2: 2-2
+s8a2: 0-0
+s8m1: 17-19
+s8n2: 0-0
+s8i: 0-0
+s8x4: 15-15
+s8p1: 12-13
+s8n3: 0-0
+s8m: 9-9
+s8n: 0-0
+s8x6: 36-36
+s8a3: 0-0
+s8x7: 27-27
+s8t: 0-0
+s8x5: 24-24
+s8n4: 0-0
+s8x8: 34-34
+s8t1: 0-0
+s8x11: 31-31
+s8x9: 30-30
+s8n5: 0-0
+s8x10: 35-35
+s8c1: 26-26
+s8c: 33-33
+
+# document level annotation:
+(s8s0 / sentence
+    :temporal ((document-creation-time :before s8x2)
+            (s8x2 :after s8x1)
+            (s8x1 :after s8x3)
+            (s8x3 :after s8x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s8x2)
+            (author :full-affirmative s8x1)
+            (author :full-affirmative s8x3)
+            (author :full-affirmative s8x6)
+            (author :full-affirmative s8p))
+    :coref ((s7x4 :same-event s8x1)
+            (s7x1 :same-event s8x6)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
+Words: 经过 12 日 的 比赛 ， 中国 以 94 金 、 76 银 、 50 铜 ， 一共 220 面 奖牌 ， 连续 六届 位居 奖牌榜 榜首
+
+# sentence level graph:
+(s9c / consecutive
+    :op1 (s9x11 / 以-01
+        :aspect state
+        :ARG1 (s9a1 / and
+            :part (s9x16 / 奖牌
+                :quant 220
+                :unit (s9x13 / 面)
+                :mod (s9x9 / 一共))
+            :op1 (s9x15 / 铜
+                :quant 50)
+            :op2 (s9x14 / 银
+                :quant 76)
+            :op3 (s9x10 / 金)
+                :quant 94)
+        :ARG0 (s9c1 / country
+                  :name (s9n1 / name :op1 "中国")))
+    :op2 (s9x / 经过-01
+        :ARG0 s9c1
+        :ARG1 (s9x2 / 比赛-01
+            :duration (s9t / temporal-quantity
+                :unit (s9x1 / 日))
+                :quant 12)
+        :aspect performance)
+    :op3 (s9x3 / 位居-01
+        :ARG0 s9c1
+        :ARG1 (s9x4 / 榜首
+            :part (s9x5 / 奖牌榜))
+        :temporal (s9x6 / 连续
+            :quant 6
+            :unit (s9x7 / 届))
+        :aspect state))
+
+# alignment:
+s9c: 0-0
+s9x11: 8-8
+s9a1: 0-0
+s9x16: 21-21
+s9x13: 20-20
+s9x9: 18-18
+s9x15: 16-16
+s9x14: 13-13
+s9x10: 10-10
+s9c1: 7-7
+s9n1: 0-0
+s9x: 1-1
+s9x2: 5-5
+s9t: 0-0
+s9x1: 3-3
+s9x3: 25-25
+s9x4: 27-27
+s9x5: 26-26
+s9x6: 23-23
+s9x7: 24-24
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((document-creation-time :before s9x11)
+            (s9x11 :after s9x3))
+    :modal ((root :modal author)
+            (author :full-affirmative s9x3)
+            (author :full-affirmative s9x11)
+            (author :full-affirmative s9x)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+Words: 49 金 、 44 银 、 31 铜 ， 合共 124 面 奖牌 的 英国 排 第二
+
+# sentence level graph:
+(s10x1 / 排
+    :aspect state
+    :ARG1 (s10x / 第二)
+    :ARG0 (s10c / country
+              :name (s10n / name :op1 "英国"))
+        :ARG1-of (s10h / have-91)
+            :ARG2 (s10a / and
+                :part (s10x5 / 奖牌
+                    :mod (s10x7 / 合共)
+                    :quant 124
+                    :unit (s10x6 / 面))
+                :op1 (s10x4 / 铜
+                    :quant 31)
+                :op2 (s10x3 / 银)
+                    :quant 44)
+                :op1 (s10x2 / 金)
+                    :quant 49)
+
+# alignment:
+s10x1: 16-16
+s10x: 17-17
+s10c: 15-15
+s10n: 0-0
+s10h: 0-0
+s10a: 0-0
+s10x5: 13-13
+s10x7: 10-10
+s10x6: 12-12
+s10x4: 8-8
+s10x3: 5-5
+s10x2: 2-2
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((document-creation-time :before s10x1))
+    :modal ((root :modal author)
+            (author :full-affirmative s10x1)))
+
+

--- a/chinese/umr_data/chinese_umr-0035.umr
+++ b/chinese/umr_data/chinese_umr-0035.umr
@@ -1,0 +1,1586 @@
+################################################################################
+# meta-info
+# :: snt1
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59
+Words: 2025 年 美国 总统 就职 典礼 ， 官方 名称 为 第 60 届 美国 总统 就职 典礼 （ 英语 ： The 60 th Presidential Inauguration ） ， 也 称为 唐纳德 · 特朗普 第二 次 总统 就职 典礼 ， 为 第 47 任 美国 总统 唐纳德 · 特朗普 于 2025 年 1 月 20 日 周一 举行 的 就职 典礼
+
+# sentence level graph:
+(s1a / and
+    :op1 (s1i8 / identity-91
+        :ARG1 s1x11
+        :ARG2 (s1x16 / 典礼
+            :mod (s1x3 / 就职)
+            :ARG1-of (s1x12 / 举行-01
+                :ARG0 (s1i9 / individual-person
+                    :name (s1n / name
+                        :op1 "唐纳德"
+                        :op2 "·"
+                        :op3 "特朗普")
+                    :ARG1-of (s1i10 / identity-91
+                        :aspect state
+                        :ARG2 (s1p / president
+                            :place (s1c / country
+                                       :name (s1n2 / name :op1 "美国"))
+                            :ord (s1o3 / ordinal-entity
+                                :value 47
+                                :unit (s1x18 / 任)))))
+                :aspect performance
+                :temporal (s1d / date-entity
+                    :weekday (s1x2 / 周一)
+                    :year 2025
+                    :month 1
+                    :day 20))))
+    :op2 (s1i2 / identity-91
+        :ARG1 (s1x10 / 典礼
+            :mod (s1x7 / 就职-01
+                :ARG2 (s1x17 / 总统))
+            :place (s1c2 / country
+                :name (s1n4 / name
+                    :op1 "美国"))
+            :temporal (s1d3 / date-entity
+                :year 2025))
+        :aspect state
+        :ARG2 (s1x6 / 典礼
+            :ord (s1o1 / ordinal-entity
+                :value 60
+                :unit (s1x4 / 届))
+            :mod (s1x15 / 就职-01
+                :ARG2 (s1x5 / 总统))
+            :place (s1c1 / country
+                       :name (s1n6 / name :op1 "美国"))
+            :ARG2-of (s1x8 / 名称-为
+                :ARG0 (s1x13 / 官方)
+                :aspect state)
+            :ARG1-of (s1i / identity-91
+                :ARG2 (s1t / The-6-0-th-Presidential-Inauguration))))
+    :op3 (s1x9 / 称为-01
+        :ARG2 (s1x11 / 典礼
+            :mod (s1x / 就职-01
+                :ARG2 (s1x1 / 总统))
+            :possessor (s1x14 / 唐纳德-特朗普)
+            :ord (s1o / ordinal-entity
+                :value 2
+                :unit (s1x19 / 次)))
+        :aspect state
+        :ARG1 s1i2))
+
+# alignment:
+s1a: 0-0
+s1i8: 0-0
+s1x12: 56-56
+s1n: 0-0
+s1i10: 0-0
+s1p: 0-0
+s1n2: 0-0
+s1o3: 0-0
+s1d: 0-0
+s1x2: 55-55
+s1i2: 0-0
+s1n4: 0-0
+s1d3: 0-0
+s1o1: 0-0
+s1x4: 13-13
+s1n6: 0-0
+s1x13: 8-8
+s1i: 0-0
+s1x9: 29-29
+s1o: 0-0
+s1x16: 6-6
+s1x3: 36-36
+s1i9: 30-47
+s1c: 3-3
+s1x10: 17-17
+s1x7: 16-16
+s1x17: 15-15
+s1c2: 14-14
+s1x6: 37-37
+s1x15: 5-5
+s1x5: 4-4
+s1c1: 43-43
+s1x8: 9-9
+s1t: 25-25
+s1x11: 59-59
+s1x: 58-58
+s1x1: 44-44
+s1x14: 47-47
+
+# document level annotation:
+(s1s0 / sentence
+    :temporal ((document-creation-time :before s1x8)
+            (s1x8 :overlap s1x9))
+    :modal ((root :modal author)
+            (author :full-affirmative s1x8)
+            (author :full-affirmative s1x9)
+            (author :full-affirmative s1x12)))
+
+
+################################################################################
+# meta-info
+# :: snt2
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
+Words: 美国 总统 当选人 唐纳德 · 特朗普 与 美国 副 总统 当选人 J · D · 万斯 在 这天 正式 宣誓 就职 ， 标志着 二人 领导 的 共和党 政府 4年 任期 的 开始
+
+# sentence level graph:
+(s2x / 宣誓-01
+    :ARG0-of (s2x13 / 标志-01
+        :ARG1 (s2x8 / 开始-01
+            :aspect process
+            :ARG1 (s2x5 / 政府
+                :ARG2-of (s2x11 / 领导-01
+                    :ARG0 (s2x12 / 二人))
+                :mod (s2x6 / 共和党)
+                :duration (s2t / temporal-quantity
+                    :unit (s2x14 / 年)
+                    :quant 4))))
+    :temporal (s2x10 / 这天)
+    :ARG0 (s2a / and
+        :op1 (s2i3 / individual-person
+            :name (s2n / name
+                :op1 "唐纳德"
+                :op2 "·"
+                :op3 "特朗普")
+            :ARG1-of (s2h / have-org-role-92
+                :ARG3 (s2x1 / 当选人
+                    :mod (s2x18 / 总统))
+                :ARG2 (s2c / country
+                          :name (s2n1 / name :op1 "美国"))))
+        :op2 (s2i2 / individual-person
+            :name (s2n2 / name
+                :op1 "J"
+                :op2 "·"
+                :op3 "D"
+                :op4 "·"
+                :op5 "万斯")
+            :ARG1-of (s2h1 / have-org-role-92
+                :ARG3 (s2x4 / 当选人
+                    :mod (s2x7 / 总统
+                        :mod (s2x9 / 副)))
+                :ARG2 (s2c1 / country
+                          :name (s2n3 / name :op1 "美国")))))
+    :mod (s2x2 / 正式)
+    :purpose (s2x3 / 就职-01
+        :aspect process
+        :ARG0 s2a))
+
+# alignment:
+s2x: 20-20
+s2x13: 23-23
+s2x8: 32-32
+s2x5: 28-28
+s2x11: 25-25
+s2x12: 24-24
+s2x6: 27-27
+s2t: 0-0
+s2x14: 29-29
+s2x10: 18-18
+s2a: 0-0
+s2i3: 4-15
+s2n: 0-0
+s2h: 0-0
+s2n1: 0-0
+s2i2: 5-16
+s2n2: 0-0
+s2h1: 0-0
+s2x9: 9-9
+s2n3: 0-0
+s2x2: 19-19
+s2x3: 21-21
+s2x1: 3-3
+s2x18: 2-2
+s2c: 1-1
+s2x4: 11-11
+s2x7: 10-10
+s2c1: 8-8
+
+# document level annotation:
+(s2s0 / sentence
+    :temporal ((document-creation-time :before s2x)
+            (s2x :after s2x3)
+            (s2x3 :overlap s2x13))
+    :modal ((root :modal author)
+            (author :full-affirmative s2x)
+            (author :full-affirmative s2x3)
+            (author :full-affirmative s2x13)
+            (author :full-affirmative s2x8))
+    :coref ((s1i9 :same-entity s2i3)))
+
+
+################################################################################
+# meta-info
+# :: snt3
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39
+Words: 根据 传统 ， 2025 年 1 月 17 日 到 21 日 ， 首都 华盛顿 特区 会 举办 音乐会 、 宣誓 仪式 、 午宴 、 游行 、 就职 舞会 、 各 宗教 派别 就职 祷告 仪式 等 就职 活动
+
+# sentence level graph:
+(s3x / 举办-01
+    :aspect habitual
+    :reason (s3x3 / 传统)
+    :ARG0 (s3g / government-organization
+              :name (s3n / name :op1 "特区")
+        :mod (s3c / country-region
+                 :name (s3n1 / name :op1 "华盛顿")
+            :mod (s3x1 / 首都)))
+    :temporal (s3d / date-interval
+        :op1 (s3d2 / date-entity
+            :day 21
+            :month 1
+            :year 2025)
+        :op2 (s3d1 / date-entity
+            :day 17
+            :month 1
+            :year 2025))
+    :ARG1 (s3x2 / 活动
+        :topic (s3x5 / 就职-01)
+        :example (s3a / and
+            :op1 (s3x6 / 音乐会)
+            :op2 (s3x7 / 仪式
+                :topic (s3x8 / 宣誓-01))
+            :op3 (s3x9 / 午宴)
+            :op4 (s3x10 / 游行-01)
+            :op5 (s3x11 / 舞会
+                :topic (s3x12 / 就职-01))
+            :op6 (s3x13 / 仪式
+                :topic (s3x14 / 祷告-01
+                    :cause (s3x15 / 就职-01
+                        :ARG1 (s3x16 / 派别
+                            :mod (s3x4 / 宗教)
+                            :mod (s3x17 / 各))))))))
+
+# alignment:
+s3x: 18-18
+s3x3: 2-2
+s3g: 16-16
+s3n: 0-0
+s3c: 15-15
+s3n1: 0-0
+s3x1: 14-14
+s3d: 0-0
+s3d2: 0-0
+s3d1: 0-0
+s3x2: 39-39
+s3a: 0-0
+s3x6: 19-19
+s3x8: 21-21
+s3x9: 24-24
+s3x10: 26-26
+s3x11: 29-29
+s3x14: 35-35
+s3x16: 33-33
+s3x4: 32-32
+s3x17: 31-31
+s3x5: 38-38
+s3x7: 22-22
+s3x12: 28-28
+s3x13: 36-36
+s3x15: 34-34
+
+# document level annotation:
+(s3s0 / sentence
+    :temporal ((document-creation-time :before s3x))
+    :modal ((root :modal author)
+            (author :full-affirmative s3x)))
+
+
+################################################################################
+# meta-info
+# :: snt4
+Index: 1 2 3 4 5 6 7 8 9 10
+Words: 这次 就职 典礼 的 主题 是 “ 恢复 信心 ”
+
+# sentence level graph:
+(s4h1 / have-topic-91
+    :aspect state
+    :ARG2 (s4x2 / 恢复-01
+        :ARG0 (s4x3 / 信心))
+    :ARG1 (s4c / ceremony
+              :name (s4n / name :op1 "典礼")
+        :mod (s4x / 这次))
+        :mod (s4x4 / 就职-01))
+
+# alignment:
+s4h1: 0-0
+s4x2: 8-8
+s4x3: 9-9
+s4c: 3-3
+s4n: 0-0
+s4x: 1-1
+s4x4: 2-2
+
+# document level annotation:
+(s4s0 / sentence
+    :temporal ((document-creation-time :before s4h1))
+    :modal ((root :modal author)
+            (author :full-affirmative s4h1))
+    :coref ((s1x16 :same-event s4c)))
+
+
+################################################################################
+# meta-info
+# :: snt5
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54
+Words: 2025 年 1 月 17 日 ， 考量 到 天气 预报 华盛顿 当日 最高 气温 只有 摄氏 零下 5 度 、 最低 零下 11 度 以及 风寒 效应 对 体感 温度 的 影响 ， 特朗普 宣布 为 因应 严寒 天气 将其 就职 典礼 由 美国 国会大厦 西侧 草坪 转移 到 国会大厦 圆形 大厅内 举行
+
+# sentence level graph:
+(s5a1 / and
+    :temporal (s5d / date-entity
+        :day 17
+        :month 1
+        :year 2025)
+    :op1 (s5x1 / 宣布-01
+        :ARG1 (s5x14 / 转移-01
+            :ARG2 (s5x21 / 大厅内
+                :part (s5b1 / building
+                          :name (s5n4 / name :op1 "国会大厦"))
+                :mod (s5x22 / 圆形))
+            :ARG3 (s5x19 / 草坪
+                :part (s5b / building
+                          :name (s5n2 / name :op1 "国会大厦")
+                    :place (s5c1 / country
+                               :name (s5n3 / name :op1 "美国")))
+                :mod (s5x20 / 西侧))
+            :ARG1 (s5x17 / 典礼
+                :ARG1-of (s5x23 / 举行-01)
+                :possessor s5p
+                :purpose (s5x18 / 就职))
+            :cause (s5x15 / 天气)
+                :mod (s5x16 / 严寒))
+        :ARG0 (s5p / person
+                  :name (s5n1 / name :op1 "特朗普")))
+    :op2 (s5x / 考量-01)
+    	:ARG1 (s5a / and
+            :op1 (s5x9 / 影响-01
+            	:ARG1 (s5x12 / 温度)
+            	    :mod (s5x13 / 体感))
+        	:ARG0 (s5x10 / 效应)
+       		    :mod (s5x11 / 风寒))
+            :op3 (s5x2 / 预报-01
+                 :temporal (s5x4 / 当日)
+                 :place (s5c / country-region
+                            :name (s5n / name :op1 "华盛顿"))
+                 :ARG1 (s5a2 / and
+                     :op1 (s5i1 / identity-91
+                         :ARG2 (s5t / temperature-quantity
+                             :unit (s5d1 / degree))
+                             :quant -11)
+                         :ARG1 (s5x7 / 气温)
+                             :mod (s5x8 / 最低))
+                     :op1 (s5i / identity-91
+                         :ARG2 (s5t1 / temperature-quantity
+                             :quant -5)
+                             :unit (s5d2 / degree))
+                         :ARG1 (s5x5 / 气温)
+                             :mod (s5x6 / 最高))
+                 :ARG0 (s5x3 / 天气))
+
+# alignment:
+s5a1: 0-0
+s5d: 0-0
+s5x1: 36-36
+s5x14: 49-49
+s5x21: 53-53
+s5n4: 0-0
+s5x22: 52-52
+s5x19: 48-48
+s5n2: 0-0
+s5c1: 45-45
+s5n3: 0-0
+s5x20: 47-47
+s5x17: 43-43
+s5x23: 54-54
+s5x18: 42-42
+s5x16: 39-39
+s5p: 0-0
+s5n1: 0-0
+s5x: 8-8
+s5a: 0-0
+s5x9: 33-33
+s5x12: 31-31
+s5x13: 30-30
+s5x10: 28-28
+s5x11: 27-27
+s5x2: 11-11
+s5x4: 13-13
+s5c: 12-12
+s5n: 0-0
+s5a2: 0-0
+s5i1: 0-0
+s5t: 0-0
+s5d1: 0-0
+s5x7: 15-15
+s5x8: 22-22
+s5i: 0-0
+s5t1: 0-0
+s5d2: 0-0
+s5x5: 15-15
+s5x6: 14-14
+s5b1: 51-51
+s5b: 46-46
+s5x15: 40-40
+s5x3: 10-10
+
+# document level annotation:
+(s5s0 / sentence
+    :temporal ((document-creation-time :before s5x)
+            (s5x :after s5x1)
+            (s5x1 :after s5x14)
+            (s5x14 :after s5x23))
+    :modal ((root :modal author)
+            (author :full-affirmative s5x)
+            (author :full-affirmative s5x1)
+            (author :full-affirmative s5x14)
+            (author :full-affirmative s5x23))
+    :coref ((s4c :same-event s5x17)))
+
+
+################################################################################
+# meta-info
+# :: snt6
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39
+Words: 这 是 自 1985 年 1 月 21 日 第 40 任 美国 总统 罗纳德 · 里根 及 第 43 任 美国 副 总统 乔治 · 赫伯特 · 沃克 · 布什 的 就职 典礼 以来 再次 于 室内 举行
+
+# sentence level graph:
+(s6x / 举行-01
+    :aspect performance
+    :temporal (s6x1 / 以来
+       :op1 (s6c1 / ceremony
+            :name (s6n1 / name :op1 "典礼")
+            :mod (s6x5 / 就职-01)
+            :possessor (s6a / and
+                :op1 (s6p1 / person
+                    :name (s6n3 / name
+                        :op1 "乔治"
+                        :op2 "·"
+                        :op3 "赫伯特"
+                        :op4 "·"
+                        :op5 "沃克"
+                        :op6 "·"
+                        :op7 "布什")
+                    :ARG1-of (s6i5 / identity-91
+                        :ARG2 (s6x6 / 总统
+                            :place (s6c2 / country
+                                :name (s6n4 / name
+                                    :op1 "美国"))
+                            :mod (s6x9 / 副)
+                            :ord (s6o2 / ordinal-entity
+                                :value 43
+                                :unit (s6x12 / 任)))))
+                :op2 (s6p / person
+                    :name (s6n / name
+                        :op1 "罗纳德"
+                        :op2 "·"
+                        :op3 "里根")
+                    :ARG1-of (s6i6 / identity-91
+                        :ARG2 (s6x7 / 总统
+                            :ord (s6o3 / ordinal-entity
+                                :value 40
+                                :unit (s6x8 / 任))
+                            :place (s6c / country
+                                :name (s6n2 / name
+                                    :op1 "美国"))))))
+                :temporal (s6d1 / date-entity
+                    :day 21
+                    :year 1985
+                    :month 1)))
+    :place (s6x2 / 室内)
+    :mod (s6x3 / 再次))
+
+# alignment:
+s6x: 39-39
+s6x1: 35-35
+s6c1: 34-34
+s6n1: 0-0
+s6x5: 33-33
+s6a: 0-0
+s6p1: 16-31
+s6n3: 0-0
+s6i5: 0-0
+s6n4: 0-0
+s6x9: 23-23
+s6o2: 0-0
+s6p: 15-30
+s6n: 0-0
+s6i6: 0-0
+s6o3: 0-0
+s6n2: 0-0
+s6d1: 0-0
+s6x2: 38-38
+s6x3: 36-36
+s6x6: 24-24
+s6c2: 22-22
+s6x12: 21-21
+s6x7: 14-14
+s6x8: 12-12
+s6c: 13-13
+
+# document level annotation:
+(s6s0 / sentence
+    :temporal ((document-creation-time :before s6x))
+    :modal ((root :modal author)
+            (author :full-affirmative s6x)))
+
+
+################################################################################
+# meta-info
+# :: snt7
+Index: 1 2 3 4 5 6 7 8 9 10 11
+Words: 佩洛西 等 20 多位 民主党 众议员 未 参加 此次 就职 典礼
+
+# sentence level graph:
+(s7x / 参加-01
+    :ARG0 (s7x1 / 众议员
+        :example (s7p / person
+                     :name (s7n1 / name :op1 "佩洛西"))
+        :mod (s7x4 / 民主党)
+        :unit (s7x3 / 位)
+        :quant (s7x9 / 多)
+            :op1 20)
+    :ARG1 (s7x6 / 典礼
+        :mod (s7x7 / 就职
+            :mod (s7x8 / 此次)))
+    :aspect performance
+    :polarity -)
+
+# alignment:
+s7x: 8-8
+s7x1: 6-6
+s7p: 0-0
+s7n1: 0-0
+s7x4: 5-5
+s7x3: 4-4
+s7x9: 4-4
+s7x6: 11-11
+s7x7: 10-10
+s7x8: 9-9
+
+# document level annotation:
+(s7s0 / sentence
+    :temporal ((document-creation-time :before s7x))
+    :modal ((root :modal author)
+            (author :full-negative s7x))
+    :coref ((s5x17 :same-event s7x6)))
+
+
+################################################################################
+# meta-info
+# :: snt8
+Index: 1
+Words: 背景
+
+# sentence level graph:
+(s8x / 背景)
+
+# alignment:
+s8x: 1-1
+
+# document level annotation:
+(s8s0 / sentence
+    :modal ((root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt9
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22
+Words: 就职 典礼 标志 着 在 2024 年 美国 总统 选举 中 当选 的 唐纳德 · 特朗普 正式 结束 总统 过渡期 并就任 总统
+
+# sentence level graph:
+(s9x / 标志-01
+    :ARG0 (s9x4 / 典礼
+        :mod (s9x9 / 就职))
+    :ARG1 (s9a / and
+        :op1 (s9x14 / 就任-01
+            :ARG0 s9i2
+            :aspect state
+            :ARG1 (s9x7 / 总统)
+        :op1 (s9x1 / 结束-01
+            :aspect state
+            :mod (s9x6 / 正式)
+            :ARG1 (s9x5 / 过渡期)
+                :mod (s9x2 / 总统))
+            :ARG0 (s9i2 / individual-person
+                :ARG0-of (s9x10 / 当选-01
+                    :aspect performance
+                    :place (s9x11 / 中
+                        :op1 (s9x12 / 选举-01
+                            :place (s9c / country
+                                :name (s9n2 / name
+                                    :op1 "美国"))
+                            :temporal (s9d2 / date-entity
+                                :year 2024)
+                            :topic (s9x3 / 总统))))
+                :name (s9n / name
+                    :op1 "唐纳德"
+                    :op2 "·"
+                    :op3 "特朗普")))
+    :aspect state))
+
+# alignment:
+s9x: 3-3
+s9x4: 2-2
+s9x9: 1-1
+s9a: 0-0
+s9x14: 21-21
+s9x1: 18-18
+s9x6: 17-17
+s9x5: 20-20
+s9i2: 14-16
+s9x10: 12-12
+s9x11: 11-11
+s9x12: 10-10
+s9c: 8-8
+s9n2: 0-0
+s9d2: 0-0
+s9n: 0-0
+s9x7: 19-19
+s9x2: 22-22
+s9x3: 9-9
+
+# document level annotation:
+(s9s0 / sentence
+    :temporal ((document-creation-time :before s9x)
+            (s9x :overlap s9x1)
+            (s9x1 :after s9x14))
+    :modal ((root :modal author)
+            (author :full-affirmative s9x)
+            (author :full-affirmative s9x1)
+            (author :full-affirmative s9x14)
+            (author :full-affirmative s9x10))
+    :coref ((s7x6 :same-event s9x4)
+            (s5p :same-entity s9i2)))
+
+
+################################################################################
+# meta-info
+# :: snt10
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
+Words: 特朗普 自 就职 起 凭借 78 岁 7 月 6 天 的 高龄 ， 打破 乔·拜登 的 纪录 ， 成为 上任 时 最 年长 的 美国 总统
+
+# sentence level graph:
+(s10a1 / and
+    :op1 (s10x4 / 成为-01
+        :ARG0 s10i3
+        :aspect performance
+        :ARG1 (s10x11 / 总统
+            :place (s10c / country
+                :name (s10n3 / name
+                    :op1 "美国"))
+            :ARG1-of (s10h1 / have-degree-91
+                :temporal (s10x12 / 上任-01)
+                :ARG5 (s10x5 / 总统
+                    :place (s10c1 / country
+                               :name (s10n / name :op1 "美国")))
+                :ARG2 (s10x6 / 年长)
+                :ARG3 (s10x13 / 最)))
+    :op1 (s10x2 / 打破-01
+        :temporal (s10x / 起
+            :op1 (s10x1 / 就职-01)
+            :ARG0 s10i3)
+        :ARG0 (s10i3 / individual-person
+            :name (s10n4 / name
+                :op1 "特朗普"))
+        :ARG1 (s10x3 / 纪录
+            :possessor (s10i4 / individual-person
+                :name (s10n5 / name
+                    :op1 "乔·拜登")))
+        :aspect performance
+        :cause (s10x9 / 高龄
+            :op1 (s10t2 / temporal-quantity
+                :unit (s10x7 / 岁)
+                :quant 78)
+            :op2 (s10t1 / temporal-quantity
+                :unit (s10x8 / 月)
+                :quant 7)
+            :op3 (s10t3 / temporal-quantity
+                :quant 6
+                :unit (s10x10 / 天))))))
+
+# alignment:
+s10a1: 0-0
+s10x4: 20-20
+s10x11: 27-27
+s10c: 26-26
+s10n3: 0-0
+s10h1: 0-0
+s10x12: 21-21
+s10x5: 27-27
+s10c1: 26-26
+s10n: 0-0
+s10x6: 24-24
+s10x13: 23-23
+s10x2: 15-15
+s10x: 4-4
+s10x1: 3-3
+s10i3: 1-1
+s10n4: 0-0
+s10x3: 18-18
+s10i4: 16-16
+s10n5: 0-0
+s10x9: 13-13
+s10t2: 0-0
+s10x7: 7-7
+s10t1: 0-0
+s10x8: 9-9
+s10t3: 0-0
+s10x10: 11-11
+
+# document level annotation:
+(s10s0 / sentence
+    :temporal ((document-creation-time :before s10x2)
+            (s10x2 :after s10x4))
+    :modal ((root :modal author)
+            (author :full-affirmative s10x2)
+            (author :full-affirmative s10x4)
+            (author :full-affirmative s10h1))
+    :coref ((s9i2 :same-entity s10i3)))
+
+
+################################################################################
+# meta-info
+# :: snt11
+Index: 1 2 3
+Words: 国会 联合 委员会
+
+# sentence level graph:
+(s11x1 / 委员会
+    :part-of (s11x2 / 国会)
+    :mod (s11x / 联合))
+
+# alignment:
+s11x1: 3-3
+s11x2: 1-1
+s11x: 2-2
+
+# document level annotation:
+(s11s0 / sentence
+    :modal ((root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt12
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35
+Words: 2024 年 5 月 ， 国会 两院 任命 了 一个 就职 典礼 联合 委员会 ， 以 监督 平台 和 其他 临时 结构 的 建设 ， 这些 建筑 预计 将 用于 户外 仪式 和 庆祝 活动
+
+# sentence level graph:
+(s12a1 / and
+    :op1 (s12x11 / 预计-01
+        :aspect state
+        :ARG1 (s12x12 / 用于-01
+            :ARG1 (s12x13 / 建筑
+                :mod (s12x14 / 这些))
+            :aspect state
+            :ARG2 (s12a / and
+                :op1 (s12x18 / 活动
+                    :mod (s12x19 / 庆祝))
+                :op2 (s12x16 / 仪式
+                    :mod (s12x17 / 户外)))
+            :mod (s12x15 / 将)))
+    :op2 (s12x / 任命-01
+        :purpose (s12x3 / 监督-01
+            :aspect habitual
+            :ARG0 s12x23
+            :ARG1 (s12a2 / and
+                :op1 (s12x5 / 平台)
+                :op2 (s12x25 / 建设
+                    :ARG1-of (s12x8 / 结构
+                        :temporal (s12x10 / 临时))
+                :mod (s12x9 / 其他))))
+        :ARG2 (s12x23 / 委员会
+            :purpose (s12x6 / 典礼
+                :mod (s12x7 / 就职))
+            :mod (s12x24 / 联合)
+            :unit (s12x4 / 个)
+            :quant 1)
+        :ARG0 (s12x2 / 国会
+            :unit (s12x1 / 院)
+            :quant 2)
+        :aspect performance
+        :temporal (s12d / date-entity
+            :month 5
+            :year 2024)))
+
+# alignment:
+s12a1: 0-0
+s12x11: 28-28
+s12x12: 30-30
+s12x13: 27-27
+s12x14: 26-26
+s12a: 0-0
+s12x18: 35-35
+s12x19: 34-34
+s12x16: 32-32
+s12x17: 31-31
+s12x15: 29-29
+s12x: 8-8
+s12x3: 17-17
+s12a2: 0-0
+s12x5: 18-18
+s12x25: 24-24
+s12x8: 22-22
+s12x10: 21-21
+s12x9: 20-20
+s12x23: 14-14
+s12x6: 12-12
+s12x7: 11-11
+s12x24: 13-13
+s12x4: 10-10
+s12x2: 6-6
+s12x1: 7-7
+s12d: 0-0
+
+# document level annotation:
+(s12s0 / sentence
+    :temporal ((document-creation-time :before s12x)
+            (s12x :after s12x3)
+            (s12x3 :after s12x11))
+    :modal ((root :modal author)
+            (author :full-affirmative s12x)
+            (author :full-affirmative s12x3)
+            (author :full-affirmative s12x11)
+            (author :partial-affirmative s12x12)))
+
+
+################################################################################
+# meta-info
+# :: snt13
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13
+Words: 首届 平台 的 建造 仪式 于 2024 年 9 月 18 日 开始
+
+# sentence level graph:
+(s13x / 开始-01
+    :aspect state
+    :ARG1 (s13x2 / 仪式
+        :possessor (s13x3 / 平台
+            :mod (s13x4 / 首届))
+        :purpose (s13x1 / 建造))
+    :temporal (s13d / date-entity
+        :year 2024
+        :month 9
+        :day 18))
+
+# alignment:
+s13x: 13-13
+s13x2: 5-5
+s13x3: 2-2
+s13x4: 1-1
+s13x1: 4-4
+s13d: 0-0
+
+# document level annotation:
+(s13s0 / sentence
+    :temporal ((document-creation-time :before s13x))
+    :modal ((root :modal author)
+            (author :full-affirmative s13x)))
+
+
+################################################################################
+# meta-info
+# :: snt14
+Index: 1
+Words: 安全
+
+# sentence level graph:
+(s14x / 安全)
+
+# alignment:
+s14x: 1-1
+
+# document level annotation:
+(s14s0 / sentence
+    :modal ((root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt15
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67
+Words: 2024 年 10 月 、 美国 国会 警察 进行 了 一次 情报 评估 ， 结论 是 ， 一个 激进 组织 “ 曾 进行 过 大规模 的 非法 示威 活动 ， 无论 结果 如何 ， 都 计划 抗议 就职 典礼 ” ， 而 其他 抗议 以色列-哈马斯 战争 的 组织 “ 几乎 肯定 会 以 就职 典礼 为 目标 ” ， 无论 美国 总统 大选 的 获胜者 是 谁
+
+# sentence level graph:
+(s15a / and
+    :op1 (s15x / 进行-01
+        :frequency (s15x35 / 1)
+        :ARG0 (s15x2 / 警察
+            :possessor (s15g / government-organization
+                           :name (s15n / name :op1 "国会"))
+                :place (s15c / country
+                           :name (s15n1 / name :op1 "美国")))
+        :ARG1 (s15x3 / 评估-01
+            :ARG1 (s15x4 / 情报)
+            :aspect performance)
+        :temporal (s15d / date-entity
+            :year 2024
+            :month 10)
+        :aspect performance)
+    :op2 (s15i2 / identity-91
+        :ARG2 (s15a1 / and
+            :op1 (s15x19 / 以
+                :aspect performance
+                :concessive-condition (s15x30 / 是
+                    :ARG1 (s15x34 / 谁)
+                    :ARG0 (s15x31 / 获胜者)
+                        :possessor (s15x32 / 大选
+                            :place (s15c1 / country
+                                       :name (s15n4 / name :op1 "美国")))
+                            :mod (s15x33 / 总统))
+                :ARG0 (s15o1 / organization
+                          :name (s15n3 / name :op1 "组织")
+                    :purpose (s15x27 / 抗议-01)
+                        :ARG1 (s15x28 / 战争-01)
+                            :place (s15x29 / 以色列-哈马斯))
+                    :mod (s15x26 / 其他))
+                :mod (s15x23 / 会
+                    :mod (s15x24 / 肯定-01)
+                        :mod (s15x25 / 几乎))
+                :purpose (s15x22 / 目标)
+                :ARG1 (s15x20 / 典礼)
+                    :mod (s15x21 / 就职-01))
+            :op1 (s15x13 / 计划-01
+                :aspect performance
+                :ARG0 s15o
+                :concessive-condition (s15x17 / 结果
+                    :manner (s15x18 / 如何-01))
+                :ARG1 (s15x14 / 抗议-01)
+                    :ARG1 (s15x15 / 典礼)
+                        :mod (s15x16 / 就职-01))
+            :op2 (s15x5 / 进行-01
+                :aspect performance
+                :ARG1 (s15x9 / 活动-01
+                    :mod (s15x12 / 大规模)
+                    :mod (s15x11 / 示威-01)
+                    :mod (s15x10 / 非法-01))
+                :mod (s15x8 / 曾))
+                :ARG0 (s15o / organization
+                          :name (s15n2 / name :op1 "组织")
+                    :unit (s15x7 / 个)
+                    :quant 1
+                    :mod (s15x6 / 激进-01))
+        :ARG1 (s15x1 / 结论)
+        :aspect state))
+
+# alignment:
+s15a: 0-0
+s15x2: 8-8
+s15g: 7-7
+s15n: 0-0
+s15n1: 0-0
+s15x3: 13-13
+s15x4: 12-12
+s15d: 0-0
+s15i2: 0-0
+s15a1: 0-0
+s15x19: 53-53
+s15x34: 67-67
+s15x31: 65-65
+s15x32: 63-63
+s15n4: 0-0
+s15x33: 62-62
+s15n3: 0-0
+s15x28: 46-46
+s15x29: 45-45
+s15x26: 43-43
+s15x23: 52-52
+s15x24: 51-51
+s15x25: 50-50
+s15x22: 57-57
+s15x13: 36-36
+s15x17: 32-32
+s15x18: 33-33
+s15x9: 29-29
+s15x12: 25-25
+s15x11: 28-28
+s15x10: 27-27
+s15x8: 22-22
+s15n2: 0-0
+s15x7: 18-18
+s15x6: 19-19
+s15x1: 15-15
+s15x: 9-9
+s15c: 6-6
+s15x30: 66-66
+s15c1: 61-61
+s15o1: 48-48
+s15x27: 44-44
+s15x20: 55-55
+s15x21: 38-38
+s15x14: 37-37
+s15x15: 39-39
+s15x16: 54-54
+s15x5: 23-23
+s15o: 20-20
+
+# document level annotation:
+(s15s0 / sentence
+    :temporal ((document-creation-time :before s15x)
+            (s15x :before s15x5)
+            (s15x5 :overlap s15x15)
+            (s15x15 :after s15x14)
+            (s15x14 :overlap s15x27))
+    :modal ((root :modal author)
+            (author :full-affirmative s15x)
+            (author :full-affirmative s15x5)
+            (author :full-affirmative s15x15)
+            (author :full-affirmative s15x14)
+            (author :full-affirmative s15x27)
+            (author :full-affirmative s15i2)
+            (author :full-affirmative s15x19)
+            (author :full-affirmative s15x13)))
+
+
+################################################################################
+# meta-info
+# :: snt16
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+Words: 参与 策划 仪式 的 机构 包括 美国国会 警察局 、 华盛顿 特区 大都会 警察局 和 美国 公园 警察局
+
+# sentence level graph:
+(s16x / 包括-01
+    :ARG0 (s16x2 / 机构
+        :ARG0-of (s16x5 / 参与-01
+            :ARG1 (s16x6 / 策划-01
+                :ARG1 (s16x7 / 仪式)
+                :aspect performance)
+            :aspect performance))
+    :ARG1 (s16a / and
+        :op1 (s16o / organization
+            :name (s16n / name
+                :op1 "美国国会"
+                :op2 "警察局"))
+        :op2 (s16o2 / organization
+            :name (s16n2 / name
+                :op1 "华盛顿"
+                :op2 "特区"
+                :op3 "大都会"
+                :op4 "警察局"))
+        :op3 (s16o3 / organization
+            :name (s16n3 / name
+                :op1 "美国"
+                :op2 "公园"
+                :op3 "警察局")))
+    :aspect state)
+
+# alignment:
+s16x: 6-6
+s16x2: 5-5
+s16x5: 1-1
+s16x6: 2-2
+s16x7: 3-3
+s16a: 0-0
+s16o: 7-17
+s16n: 0-0
+s16o2: 8-17
+s16n2: 0-0
+s16o3: 8-17
+s16n3: 0-0
+
+# document level annotation:
+(s16s0 / sentence
+    :temporal ((s16x5 :overlap s16x6)
+            (s16x6 :overlap s16x)
+            (document-creation-time :before s16x5))
+    :modal ((root :modal author)
+            (author :full-affirmative s16x5)
+            (author :full-affirmative s16x6)
+            (author :full-affirmative s16x)))
+
+
+################################################################################
+# meta-info
+# :: snt17
+Index: 1 2 3 4 5 6 7 8 9 10 11
+Words: 24 个州 为 选举人票 认证 和 就职 典礼 提供 国民警卫队 支持
+
+# sentence level graph:
+(s17x / 提供-02
+    :ARG0 (s17x2 / 州
+        :unit (s17x1 / 个)
+        :quant 24)
+    :ARG1 (s17x3 / 支持-01
+        :ARG1 (s17x4 / 警卫队
+            :mod (s17x5 / 国民))
+        :aspect state)
+    :ARG2 (s17a / and
+        :op1 (s17x8 / 典礼
+            :mod (s17x10 / 就职-01))
+        :op2 (s17x6 / 认证-01
+            :ARG1 (s17x7 / 选举人票)
+            :aspect performance))
+    :aspect state)
+
+# alignment:
+s17x: 9-9
+s17x2: 2-2
+s17x1: 2-2
+s17x3: 11-11
+s17x4: 10-10
+s17x5: 10-10
+s17a: 0-0
+s17x8: 8-8
+s17x10: 7-7
+s17x6: 5-5
+s17x7: 4-4
+
+# document level annotation:
+(s17s0 / sentence
+    :temporal ((document-creation-time :before s17x))
+    :modal ((root :modal author)
+            (author :full-affirmative s17x)
+            (author :full-affirmative s17x3)
+            (author :full-affirmative s17x6)))
+
+
+################################################################################
+# meta-info
+# :: snt18
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
+Words: 1 月 17 日 ， 约 8 , 000 名 国民警卫队士兵 被 任命 为 美国 特别 副 法警 ， 赋予 他们 在 国家 首都 地区 的 警务 权力
+
+# sentence level graph:
+(s18a / and
+    :op1 (s18x / 任命-01
+        :ARG1 (s18x1 / 国民警卫队士兵
+            :quant (s18x6 / 约)
+            :op1 8000)
+        :ARG2 (s18x7 / 法警
+            :mod (s18x8 / 副)
+            :mod (s18x9 / 特别)
+            :place (s18c2 / country
+                :name (s18n / name
+                    :op1 "美国")))
+        :aspect performance)
+    :op2 (s18x5 / 赋予-01
+        :temporal (s18d / date-entity
+            :day 17
+            :month 1)
+        :ARG1 s18x7)
+        :ARG2 (s18x3 / 权力
+            :place (s18c1 / country-region
+                       :name (s18n2 / name :op1 "国家" :op2 "首都" :op3 "地区"))
+            :mod (s18x10 / 警务))
+        :aspect performance)
+
+# alignment:
+s18a: 0-0
+s18x: 13-13
+s18x1: 11-11
+s18x6: 6-6
+s18x7: 18-18
+s18x8: 17-17
+s18x9: 16-16
+s18c2: 15-15
+s18n: 0-0
+s18x5: 20-20
+s18d: 0-0
+s18x3: 28-28
+s18c1: 23-25
+s18n2: 0-0
+s18x10: 27-27
+
+# document level annotation:
+(s18s0 / sentence
+    :temporal ((document-creation-time :before s18x)
+            (s18x :after s18x5))
+    :modal ((root :modal author)
+            (author :full-affirmative s18x)
+            (author :full-affirmative s18x5)
+            (author :full-affirmative s18a)))
+
+
+################################################################################
+# meta-info
+# :: snt19
+Index: 1 2
+Words: 就职 委员会
+
+# sentence level graph:
+(s19x / 委员会
+    :purpose (s19x1 / 就职))
+
+# alignment:
+s19x: 2-2
+s19x1: 1-1
+
+# document level annotation:
+(s19s0 / sentence
+    :modal ((root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt20
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+Words: 2024 年 11 月 9 日 ， 特朗普 宣布 成立 特朗普 / 万斯 就职 委员会 ， 致力于 规划 就职 活动
+
+# sentence level graph:
+(s20x / 宣布-01
+    :aspect performance
+    :temporal (s20d / date-entity
+        :year 2024
+        :month 11
+        :day 9)
+    :ARG0 (s20i2 / individual-person
+        :name (s20n / name
+            :op1 "特朗普"))
+    :ARG1 (s20x2 / 成立-01
+        :purpose (s20x5 / 规划-01
+            :aspect habitual
+            :ARG1 (s20x6 / 活动
+                :mod (s20x7 / 就职-01)))
+        :aspect performance
+        :ARG1 (s20x3 / 委员会
+            :mod (s20x4 / 就职)
+            :name (s20n3 / name
+                :op1 "特朗普"
+                :op2 "万斯"))))
+
+# alignment:
+s20x: 9-9
+s20d: 0-0
+s20n: 0-0
+s20x2: 10-10
+s20x5: 18-18
+s20x6: 20-20
+s20x3: 8-13
+s20n3: 0-0
+s20i2: 8-8
+s20x7: 19-19
+s20x4: 14-14
+
+# document level annotation:
+(s20s0 / sentence
+    :temporal ((document-creation-time :before s20x)
+            (s20x :after s20x2)
+            (s20x2 :after s20x5))
+    :modal ((root :modal author)
+            (author :full-affirmative s20x)
+            (author :full-affirmative s20x2)
+            (author :full-affirmative s20x5))
+    :coref ((s10i3 :same-entity s20i2)))
+
+
+################################################################################
+# meta-info
+# :: snt21
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+Words: 委员会 联合 主席 是 史蒂夫 · 维特科夫 和 前 美国 参议员 凯利 · 勒弗勒 ， 他们 是 当选 总统 的 长期 朋友 和 支持者
+
+# sentence level graph:
+(s21a1 / and
+    :op1 (s21x1 / 是-01
+        :aspect state
+        :ARG1 (s21a2 / and
+            :op1 (s21x10 / 支持者)
+            :op2 (s21x8 / 朋友
+                :possessor (s21x6 / 总统
+                    :mod (s21x7 / 当选))
+                :mod (s21x9 / 长期)))
+        :ARG0 s21a)
+    :op2 (s21i / identity-91
+        :ARG2 (s21a / and
+            :op1 (s21i3 / individual-person
+                :name (s21n / name
+                    :op1 "史蒂夫"
+                    :op2 "·"
+                    :op3 "维特科夫"))
+            :op2 (s21i4 / individual-person
+                :name (s21n2 / name
+                    :op1 "凯利"
+                    :op2 "·"
+                    :op3 "勒弗勒")
+                :ARG1-of (s21i5 / identity-91
+                    :aspect state)))
+                    :ARG2 (s21x4 / 参议员
+                        :mod (s21x5 / 前)
+                        :mod (s21c / country
+                            :name (s21n3 / name
+                                :op1 "美国")))
+        :ARG1 (s21x / 主席
+            :mod (s21x2 / 联合)
+            :part-of (s21x3 / 委员会))
+        :aspect state))
+
+# alignment:
+s21a1: 0-0
+s21a2: 0-0
+s21x10: 24-24
+s21x8: 22-22
+s21x6: 19-19
+s21x7: 18-18
+s21x9: 21-21
+s21i: 0-0
+s21a: 0-0
+s21i3: 5-13
+s21n: 0-0
+s21i4: 6-14
+s21n2: 0-0
+s21i5: 0-0
+s21x4: 11-11
+s21x5: 9-9
+s21c: 10-10
+s21n3: 0-0
+s21x: 3-3
+s21x2: 2-2
+s21x3: 1-1
+s21x1: 4-4
+
+# document level annotation:
+(s21s0 / sentence
+    :temporal ((document-creation-time :before s21x1))
+    :modal ((root :modal author)
+            (author :full-affirmative s21x1)
+            (author :full-affirmative s21i)))
+
+
+################################################################################
+# meta-info
+# :: snt22
+Index: 1
+Words: 捐款
+
+# sentence level graph:
+(s22x / 捐款-01)
+
+# alignment:
+s22x: 1-1
+
+# document level annotation:
+(s22s0 / sentence
+    :modal ((root :modal author)))
+
+
+################################################################################
+# meta-info
+# :: snt23
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13
+Words: 美国 各大 科技 公司 的 领导人 承诺 为 就职 典礼 捐款 和 服务
+
+# sentence level graph:
+(s23x / 承诺-01
+    :aspect performance
+    :ARG0 (s23x2 / 领导人
+        :part (s23x3 / 公司
+            :mod (s23x4 / 科技)
+            :place (s23c / country
+                :name (s23n / name
+                    :op1 "美国"))
+            :mod (s23x5 / 各大)))
+    :ARG1 (s23a / and
+        :op1 (s23x6 / 服务-01
+            :ARG0 s23x2
+            :ARG1 s23x9
+            :aspect state)
+        :op2 (s23x8 / 捐款-01
+            :aspect state
+            :ARG0 s23x2
+            :ARG1 (s23x9 / 典礼
+                :mod (s23x1 / 就职-01)))))
+
+# alignment:
+s23x: 7-7
+s23x2: 6-6
+s23x3: 4-4
+s23x4: 3-3
+s23c: 1-1
+s23n: 0-0
+s23x5: 2-2
+s23a: 0-0
+s23x6: 13-13
+s23x8: 11-11
+s23x9: 10-10
+s23x1: 9-9
+
+# document level annotation:
+(s23s0 / sentence
+    :temporal ((s23x :after s23x8)
+            (s23x8 :overlap s23x6)
+            (document-creation-time :before s23x))
+    :modal ((root :modal author)
+            (author :full-affirmative s23x)
+            (author :unspecified s23x8)
+            (author :unspecified s23x6)
+            (author :full-affirmative s23x6)
+            (author :full-affirmative s23x8)))
+
+
+################################################################################
+# meta-info
+# :: snt24
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+Words: OpenAI 首席 执行官 萨姆 · 阿尔特曼 通过 发言人 表示 ， 他 将 个人 捐款 100 万美元
+
+# sentence level graph:
+(s24x / 表示-01
+    :medium (s24x6 / 发言人)
+    :aspect performance
+    :ARG0 (s24i3 / individual-person
+        :ARG1-of (s24h1 / have-org-role-92
+            :ARG3 (s24x1 / 执行官
+                :mod (s24x5 / 首席))
+            :ARG2 (s24c / company
+                :name (s24n2 / name
+                    :op1 "OpenAI")))
+        :name (s24n / name
+            :op1 "萨姆"
+            :op2 "·"
+            :op3 "阿尔特曼"))
+    :ARG1 (s24x2 / 捐款-01
+        :aspect state
+        :ARG0 s24i3
+        :ARG1 (s24m / monetary-quantity
+            :unit (s24x7 / 万)
+            :quant 100
+            :unit (s24x3 / 美元))
+        :mod (s24x4 / 个人)))
+
+# alignment:
+s24x: 9-9
+s24x6: 8-8
+s24i3: 4-6
+s24h1: 0-0
+s24x1: 3-3
+s24x5: 2-2
+s24c: 1-1
+s24n2: 0-0
+s24n: 0-0
+s24x2: 14-14
+s24m: 0-0
+s24x7: 16-16
+s24x3: 16-16
+s24x4: 13-13
+
+# document level annotation:
+(s24s0 / sentence
+    :temporal ((document-creation-time :before s24x)
+            (s24x :after s24x2))
+    :modal ((root :modal author)
+            (author :full-affirmative s24x)
+            (author :unspecified s24x2)
+            (author :full-affirmative s24x2)))
+
+
+################################################################################
+# meta-info
+# :: snt25
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+Words: Meta 负责人 、 Facebook 和 Instagram 的 马克 · 扎克伯格 捐赠 了 100 万美元
+
+# sentence level graph:
+(s25x / 捐赠-01
+    :aspect performance
+    :ARG1 (s25m / monetary-quantity
+        :unit (s25x2 / 万)
+        :quant 100
+        :unit (s25x3 / 美元))
+    :ARG0 (s25i2 / individual-person
+        :ARG1-of (s25h / have-org-role-92
+            :ARG3 (s25x1 / 负责人)
+            :ARG2 (s25a / and
+                :op1 (s25c / company
+                    :name (s25n2 / name
+                        :op1 "Facebook"))
+                :op2 (s25c2 / company
+                    :name (s25n3 / name
+                        :op1 "Instagram"))
+                :op3 (s25c3 / company
+                    :name (s25n4 / name
+                        :op1 "Meta"))
+                :name (s25n / name
+                    :op1 "马克"
+                    :op2 "·"
+                    :op3 "扎克伯格")))))
+
+# alignment:
+s25x: 11-11
+s25m: 0-0
+s25x2: 14-14
+s25x3: 14-14
+s25i2: 0-0
+s25h: 0-0
+s25x1: 2-2
+s25a: 8-10
+s25c: 4-4
+s25n2: 0-0
+s25c2: 6-6
+s25n3: 0-0
+s25c3: 1-1
+s25n4: 0-0
+s25n: 0-0
+
+# document level annotation:
+(s25s0 / sentence
+    :temporal ((document-creation-time :before s25x))
+    :modal ((root :modal author)
+            (author :full-affirmative s25x)))
+
+
+################################################################################
+# meta-info
+# :: snt26
+Index: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+Words: 12 月 23 日 ， 福特 汽车 公司 和 通用 汽车 公司 宣布 将 各 捐赠 100 万美元 并 为 总统 就职 典礼 提供 车队
+
+# sentence level graph:
+(s26x1 / 宣布
+    :aspect performance
+    :ARG0 (s26a2 / and
+        :op1 (s26c / company
+            :name (s26n1 / name
+                :op1 "福特"
+                :op2 "汽车"
+                :op3 "公司"))
+        :op2 (s26c2 / company
+            :name (s26n2 / name
+                :op1 "通用"
+                :op2 "汽车"
+                :op3 "公司")))
+    :temporal (s26d / date-entity
+        :day 23
+        :month 12)
+    :ARG1 (s26a / and
+        :op1 (s26x3 / 捐赠-01
+            :aspect state
+            :ARG1 (s26m / monetary-quantity
+                :unit (s26x5 / 万美元)
+                :quant 100)
+            :ARG0 s26a2)
+        :mod (s26x2 / 将)
+        :op2 (s26x6 / 提供-01
+            :aspect state
+            :ARG0 s26a2
+            :ARG1 (s26x10 / 车队)
+            :ARG2 (s26x9 / 典礼
+                :mod (s26x7 / 就职-01
+                    :ARG2 (s26x8 / 总统))))))
+
+# alignment:
+s26x1: 13-13
+s26a2: 0-0
+s26c: 6-12
+s26n1: 0-0
+s26c2: 7-12
+s26n2: 0-0
+s26d: 0-0
+s26a: 0-0
+s26x3: 16-16
+s26m: 0-0
+s26x5: 18-18
+s26x2: 14-14
+s26x6: 24-24
+s26x10: 25-25
+s26x9: 23-23
+s26x7: 22-22
+s26x8: 21-21
+
+# document level annotation:
+(s26s0 / sentence
+    :temporal ((document-creation-time :before s26x1)
+            (s26x1 :after s26x3)
+            (s26x3 :after s26x6))
+    :modal ((root :modal author)
+            (author :full-affirmative s26x1)
+            (author :unspecified s26x3)
+            (author :unspecified s26x6)
+            (author :full-affirmative s26x3)
+            (author :full-affirmative s26x6)))
+
+


### PR DESCRIPTION
## Summary
- Add 9 new Chinese UMR annotation documents (`chinese_umr-0027.umr` through `chinese_umr-0035.umr`) to `chinese/umr_data/`
- Add `temp/` to `.gitignore` for scratch/working data

## Test plan
- [x] Verify the new `.umr` files follow the expected format
- [x] Run validation script against new files if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)